### PR TITLE
Can't use inferred types to create a generic matrix

### DIFF
--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -53,6 +53,9 @@ interface NDArray<T> {
         private var _byteFactory: NumericalNDArrayFactory<Byte>? = null
 
         fun <T> getGenericFactory(): GenericNDArrayFactory<T> = DefaultGenericNDArrayFactory<T>()
+
+        fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
+            getGenericFactory<T>().create(*dims, filler = filler)
     }
     fun getLinear(index: Int): T
     fun setLinear(index: Int, value: T)

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -52,14 +52,12 @@ interface NDArray<T> {
             set(value) { _byteFactory = value}
         private var _byteFactory: NumericalNDArrayFactory<Byte>? = null
 
-        fun <T> getGenericFactory(): GenericNDArrayFactory<T> = DefaultGenericNDArrayFactory<T>()
-
         fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
-            getGenericFactory<T>().create(*dims, filler = filler)
+            DefaultGenericNDArrayFactory<T>().create(*dims, filler = filler)
     }
     fun getLinear(index: Int): T
     fun setLinear(index: Int, value: T)
-    
+
     fun shape(): List<Int>
     fun copy(): NDArray<T>
 

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -163,15 +163,15 @@ class NDTests {
     }
     @Test
     fun testToMatrixOrNull() {
-        assert(NDArray.getGenericFactory<Double>().create(1,2){5.5}.toMatrixOrNull() != null)
-        assert(NDArray.getGenericFactory<Double>().create(6){5.5}.toMatrixOrNull() != null)
-        assert(NDArray.getGenericFactory<Long>().create(1,2){5}.toMatrixOrNull() == null)
-        assert(NDArray.getGenericFactory<String>().create(1,2){"a"}.toMatrixOrNull() == null)
+        assert(NDArray.createGeneric<Double>(1,2){5.5}.toMatrixOrNull() != null)
+        assert(NDArray.createGeneric<Double>(6){5.5}.toMatrixOrNull() != null)
+        assert(NDArray.createGeneric<Long>(1,2){5}.toMatrixOrNull() == null)
+        assert(NDArray.createGeneric<String>(1,2){"a"}.toMatrixOrNull() == null)
         assert(NDArray.doubleFactory.zeros(3,3).toMatrixOrNull() != null)
         assert(NDArray.doubleFactory.zeros(3).toMatrixOrNull() != null)
         assert(NDArray.doubleFactory.zeros(3,3,5).toMatrixOrNull() == null)
         assert(NDArray.intFactory.zeros(3,3,5,9).toMatrixOrNull() == null)
-        val a = NDArray.getGenericFactory<Any>().create(1,2){ it ->
+        val a = NDArray.createGeneric<Any>(1,2){ it ->
             if(it[1]==0)
                 1.1
             else

--- a/koma-tests/test/koma/NumNDTests.kt
+++ b/koma-tests/test/koma/NumNDTests.kt
@@ -11,7 +11,7 @@ class NumNDTests {
         val testArrs = arrayOf (
                 NDArray.doubleFactory.create(3,5,4) { idx -> idx[0].toDouble() },
                 DefaultDoubleNDArray(3,5,4) { idx -> idx[0].toDouble() },
-                NDArray.getGenericFactory<Double>().create(3,5,4) { idx -> idx[0].toDouble() }
+                NDArray.createGeneric<Double>(3,5,4) { idx -> idx[0].toDouble() }
         )
 
         for (arr in testArrs) {


### PR DESCRIPTION
**Problem**

Code that used `DefaultNDArray` before it was deprecated was supported by Kotlin type inference.

```kotlin
DefaultNDArray(2, 3, 4) { "something" }
```

But with the new factory approach, one has to specify the return value of the init function as the type parameter to getGenericFactory, because Kotlin type inference is not smart enough to work it out:

```kotlin
                      // v- compile error: need explicit type param
NDArray.getGenericFactory().create(2, 3, 4) { "something" }

// fine
NDArray.getGenericFactory<String>().create(2, 3, 4) { "something" }
```

**Supplied Solution**

This PR adds a `createGeneric` method to NDArray's companion, which is just shorthand for `getGenericFactory<T>().create(*dims) { filler() }`, using the filler's return type to infer the value of `T`

**But That Sucks**

Since you've gone to all this trouble to optimize particular types, making a convenience method that only works for boxed types feels like a backslide. Unfortunately, trying to work around that is fraught with multiplatform issues.

**What I Really Wish I Were Smart Enough To Figure Out**

The other approach I looked at was to use KClass reflection to special case primitive types:

```kotlin
inline fun <reified T> NDArray.Companion.create(vararg dims: Int,
                                                noinline filler: (IntArray) -> T)
    = when (T::class) {
    Double::class -> doubleFactory.create(*dims) { filler(it) as Double }
    Float::class  -> floatFactory.create(*dims) { filler(it) as Float }
    Long::class   -> longFactory.create(*dims) { filler(it) as Long }
    Int::class    -> intFactory.create(*dims) { filler(it) as Int }
    Byte::class   -> byteFactory.create(*dims) { filler(it) as Byte }
    else          -> getGenericFactory<T>().create(*dims, filler = filler)
}
```

This works on Java, but in JS it always picks `Double::class` because behind the scenes it's treating all of those as `typeof T === 'number'`. But, because JS doesn't really have integral types, I'm not sure there's any reason to care. I haven't been able to investigate the behavior on Native because of persistent issues with blas on my machine. 