### PR TITLE
Proposal: Invokable NDArray.Companion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,14 @@
 def ReifiedMatrices = ['T', 'Double', 'Float', 'Int']
 def ReifiedNDArrays = ['T', 'Double', 'Float', 'Long', 'Int', 'Short', 'Byte']
+def NumericalConstantSuffixes = [
+    'T': ' as T',
+    'Double': '.0',
+    'Float': '.0f',
+    'Long': 'L',
+    'Int': '',
+    'Short': '.toShort()',
+    'Byte': '.toByte()'
+]
 
 buildscript {
     ext.kotlin_version = '1.2.31'
@@ -337,7 +346,7 @@ task syncPartialGen {
     }
 }
 
-def genCode(project, namespace, dtypesMatrix, dtypesNDArray) {
+def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
     // Generate matrix types
     dtypesMatrix.forEach { dtype ->
         if (dtype != 'T') {
@@ -406,6 +415,7 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray) {
                 include 'DefaultXNDArrayFactory.kt'
                 rename { "Default${dtypeName(dtype)}NDArrayFactory.kt"}
                 expand(dtype: dtype,
+                        literalSuffix: dtypeSuffixMap[dtype],
                         namespace: namespace)
             }
         }
@@ -419,6 +429,7 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray) {
                     genDec: genDec(dtype),
                     toMatrix: toMatrix(dtype, dtypesMatrix),
                     operators: operators(dtype),
+                    factoryPrefix: dtype == "T" ? "Generic" : "Numerical",
                     inline: inline(dtype))
         }
     }
@@ -429,7 +440,7 @@ task codegen {
     doLast {
         genCode("koma-core-api/common/src/koma/internal/default/generated",
                 "koma.internal.default.generated",
-                ReifiedMatrices, ReifiedNDArrays)
+                ReifiedMatrices, ReifiedNDArrays, NumericalConstantSuffixes)
     }
 }
 
@@ -503,12 +514,12 @@ def convertGetter(baseDtype, toDtype) {
 
 def convertSetter(baseDtype, toDtype) {
     if(baseDtype == 'T')
-        return "    override fun set${toDtype}(i: Int, value: ${toDtype}) {\n" +
-               "       setGeneric(i, value as ${baseDtype})\n" +
+        return "    override fun set${toDtype}(i: Int, v: ${toDtype}) {\n" +
+               "       setGeneric(i, v as ${baseDtype})\n" +
                "    }\n"
     else
-        return "    override fun set${toDtype}(i: Int, value: ${toDtype}) {\n" +
-               "        storage[checkLinearIndex(i)] = value.to${baseDtype}()\n" +
+        return "    override fun set${toDtype}(i: Int, v: ${toDtype}) {\n" +
+               "        storage[checkLinearIndex(i)] = v.to${baseDtype}()\n" +
                "    }\n"
 }
 
@@ -618,7 +629,7 @@ def primitiveGetSet(types) {
         @KomaJsName("get${it}1D")
         fun get$it(i: Int): $it
         @KomaJsName("set${it}ND")
-        fun set$it(vararg indices: Int, value: $it) = set$it(safeIdxToLinear(indices), value)
+        fun set$it(vararg indices: Int, v: $it) = set$it(safeIdxToLinear(indices), v)
         @KomaJsName("set${it}1D")
         fun set$it(i: Int, v: $it)
     """.stripIndent() }.join("\n")
@@ -627,7 +638,7 @@ def primitiveGetSet(types) {
 def override1DPrimitiveGetSet(matrixTypes, ndTypes) {
     (ndTypes - matrixTypes).collect { """
         override fun get$it(i: Int): ${it} = getGeneric(i) as $it
-        override fun set$it(i: Int, value: $it) { setGeneric(i, value as T) }
+        override fun set$it(i: Int, v: $it) { setGeneric(i, v as T) }
     """.stripIndent() }.join("\n")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -336,13 +336,10 @@ void syncGen(File target, String marker, String code) {
 
 task syncPartialGen {
     def ndarrayFile = file("koma-core-api/common/src/koma/ndarray/NDArray.kt")
-    def matrixFile = file("koma-core-api/common/src/koma/matrix/Matrix.kt")
-    inputs.files([matrixFile, ndarrayFile, file("build.gradle")])
-    outputs.files([matrixFile, ndarrayFile])
+    inputs.files([ndarrayFile, file("build.gradle")])
+    outputs.files([ndarrayFile])
     doLast {
         syncGen(ndarrayFile, "primitive get/set",  primitiveGetSet(ReifiedNDArrays))
-        syncGen(matrixFile, "1D overrides",
-                override1DPrimitiveGetSet(ReifiedMatrices, ReifiedNDArrays))
     }
 }
 
@@ -372,6 +369,8 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
         }
         copy {
             from 'templates'
+        syncGen(matrixFile, "1D overrides",
+                override1DPrimitiveGetSet(ReifiedMatrices, ReifiedNDArrays))
             into "koma-core-api/common/src/koma/extensions"
             include 'extensions_matrix.kt'
             rename { "extensions_matrix_${dtypeName(dtype)}.kt"}
@@ -627,18 +626,11 @@ def primitiveGetSet(types) {
         @KomaJsName("get${it}ND")
         fun get$it(vararg indices: Int) = get$it(safeIdxToLinear(indices))
         @KomaJsName("get${it}1D")
-        fun get$it(i: Int): $it
+        fun get$it(i: Int): $it = (getGeneric(i) as Number).to$it()
         @KomaJsName("set${it}ND")
         fun set$it(vararg indices: Int, v: $it) = set$it(safeIdxToLinear(indices), v)
         @KomaJsName("set${it}1D")
-        fun set$it(i: Int, v: $it)
-    """.stripIndent() }.join("\n")
-}
-
-def override1DPrimitiveGetSet(matrixTypes, ndTypes) {
-    (ndTypes - matrixTypes).collect { """
-        override fun get$it(i: Int): ${it} = getGeneric(i) as $it
-        override fun set$it(i: Int, v: $it) { setGeneric(i, v as T) }
+        fun set$it(i: Int, v: $it) { setGeneric(i, v as T) }
     """.stripIndent() }.join("\n")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -620,11 +620,11 @@ def primitiveGetSet(types) {
     types.findAll { it != "T" }.collect {
         """
         @KomaJsName("get${it}ND")
-        fun get$it(vararg indices: Int) = get$it(safeIdxToLinear(indices))
+        fun get$it(vararg indices: Int) = get$it(safeNIdxToLinear(indices))
         @KomaJsName("get${it}1D")
         fun get$it(i: Int): $it = (getGeneric(i) as Number).to$it()
         @KomaJsName("set${it}ND")
-        fun set$it(vararg indices: Int, v: $it) = set$it(safeIdxToLinear(indices), v)
+        fun set$it(vararg indices: Int, v: $it) = set$it(safeNIdxToLinear(indices), v)
         @KomaJsName("set${it}1D")
         fun set$it(i: Int, v: $it) { setGeneric(i, v as T) }
         """.stripIndent().replaceAll("\n", indent)

--- a/build.gradle
+++ b/build.gradle
@@ -324,22 +324,14 @@ task buildNative {
     dependsOn(":koma-core-cblas:build")
 }
 
-void syncGen(File target, String marker, String code) {
-    target.text = target.text.replaceAll(~"(([ \t]*)//!\\{\\{ $marker\n)[\\s\\S]*?([ \t]+//!}})") {
-        it[1] + (
-            "\n// GENERATED CODE! See build.gradle\n$code\n"
-                .replaceAll("\n", "\n${it[2]}")
-                .replaceAll(~"\n[ \t]+(?=\n|\\Z)", "\n")
-        ) + it[3]
-    }
-}
-
-task syncPartialGen {
-    def ndarrayFile = file("koma-core-api/common/src/koma/ndarray/NDArray.kt")
-    inputs.files([ndarrayFile, file("build.gradle")])
-    outputs.files([ndarrayFile])
-    doLast {
-        syncGen(ndarrayFile, "primitive get/set",  primitiveGetSet(ReifiedNDArrays))
+void genNDArray(String dest, List<String> dtypesNDArray) {
+    copy {
+        from 'templates'
+        into "$dest"
+        include 'NDArray.kt'
+        expand(factories: fixWhitespaceErrors(factories(dtypesNDArray)),
+               primitiveGetSet: fixWhitespaceErrors(primitiveGetSet(dtypesNDArray)),
+               typeCheckClauses: fixWhitespaceErrors(typeCheckClauses(dtypesNDArray)))
     }
 }
 
@@ -369,8 +361,6 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
         }
         copy {
             from 'templates'
-        syncGen(matrixFile, "1D overrides",
-                override1DPrimitiveGetSet(ReifiedMatrices, ReifiedNDArrays))
             into "koma-core-api/common/src/koma/extensions"
             include 'extensions_matrix.kt'
             rename { "extensions_matrix_${dtypeName(dtype)}.kt"}
@@ -435,8 +425,8 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
 }
 
 task codegen {
-    dependsOn('syncPartialGen')
     doLast {
+        genNDArray("koma-core-api/common/src/koma/ndarray", ReifiedNDArrays)
         genCode("koma-core-api/common/src/koma/internal/default/generated",
                 "koma.internal.default.generated",
                 ReifiedMatrices, ReifiedNDArrays, NumericalConstantSuffixes)
@@ -621,8 +611,14 @@ def inline(dtype) {
     }
 }
 
+String fixWhitespaceErrors(String input) {
+    return input.replaceAll(~"\n[ \t]+(?=\n)", "\n").trim()
+}
+
 def primitiveGetSet(types) {
-    types.findAll { it != "T" }.collect { """
+    def indent = "\n    "
+    types.findAll { it != "T" }.collect {
+        """
         @KomaJsName("get${it}ND")
         fun get$it(vararg indices: Int) = get$it(safeIdxToLinear(indices))
         @KomaJsName("get${it}1D")
@@ -631,7 +627,27 @@ def primitiveGetSet(types) {
         fun set$it(vararg indices: Int, v: $it) = set$it(safeIdxToLinear(indices), v)
         @KomaJsName("set${it}1D")
         fun set$it(i: Int, v: $it) { setGeneric(i, v as T) }
-    """.stripIndent() }.join("\n")
+        """.stripIndent().replaceAll("\n", indent)
+    }.join(indent)
+}
+
+def typeCheckClauses(types) {
+    types.findAll { it != "T" }.collect {
+        String.format("%-13s -> ${it.toLowerCase()}Factory.alloc(dims).fill { filler(it) as $it }",
+                      "$it::class")
+    }.join("\n                ")
+}
+
+def factories(types) {
+    types.findAll { it != "T" }.collect {
+        def fieldName = "${it.toLowerCase()}Factory"
+        """
+        var $fieldName: NumericalNDArrayFactory<$it>
+            get() = _$fieldName ?: get${it}NDArrayFactory().also { _$fieldName = it }
+            set(value) { _$fieldName = value }
+        private var _$fieldName: NumericalNDArrayFactory<$it>? = null
+        """
+    }.join("")
 }
 
 apply from: 'buildscripts/publishing.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -419,6 +419,7 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
                     toMatrix: toMatrix(dtype, dtypesMatrix),
                     operators: operators(dtype),
                     factoryPrefix: dtype == "T" ? "Generic" : "Numerical",
+                    factoryGetter: factoryGetter(dtype),
                     inline: inline(dtype))
         }
     }
@@ -609,6 +610,10 @@ def inline(dtype) {
     else {
         return ""
     }
+}
+
+def factoryGetter(dtype) {
+    dtype == "T" ? "NDArray.allocGeneric<T>" : "NDArray.${dtype.toLowerCase()}Factory.alloc"
 }
 
 String fixWhitespaceErrors(String input) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+def ReifiedMatrices = ['T', 'Double', 'Float', 'Int']
+def ReifiedNDArrays = ['T', 'Double', 'Float', 'Long', 'Int', 'Short', 'Byte']
+
 buildscript {
     ext.kotlin_version = '1.2.31'
     ext.kotlin_native_version = '0.6.2'
@@ -312,6 +315,28 @@ task buildNative {
     dependsOn(":koma-core-cblas:build")
 }
 
+void syncGen(File target, String marker, String code) {
+    target.text = target.text.replaceAll(~"(([ \t]*)//!\\{\\{ $marker\n)[\\s\\S]*?([ \t]+//!}})") {
+        it[1] + (
+            "\n// GENERATED CODE! See build.gradle\n$code\n"
+                .replaceAll("\n", "\n${it[2]}")
+                .replaceAll(~"\n[ \t]+(?=\n|\\Z)", "\n")
+        ) + it[3]
+    }
+}
+
+task syncPartialGen {
+    def ndarrayFile = file("koma-core-api/common/src/koma/ndarray/NDArray.kt")
+    def matrixFile = file("koma-core-api/common/src/koma/matrix/Matrix.kt")
+    inputs.files([matrixFile, ndarrayFile, file("build.gradle")])
+    outputs.files([matrixFile, ndarrayFile])
+    doLast {
+        syncGen(ndarrayFile, "primitive get/set",  primitiveGetSet(ReifiedNDArrays))
+        syncGen(matrixFile, "1D overrides",
+                override1DPrimitiveGetSet(ReifiedMatrices, ReifiedNDArrays))
+    }
+}
+
 def genCode(project, namespace, dtypesMatrix, dtypesNDArray) {
     // Generate matrix types
     dtypesMatrix.forEach { dtype ->
@@ -400,11 +425,11 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray) {
 }
 
 task codegen {
+    dependsOn('syncPartialGen')
     doLast {
         genCode("koma-core-api/common/src/koma/internal/default/generated",
                 "koma.internal.default.generated",
-                ['T', 'Double', 'Float', 'Int'],
-                ['T', 'Double', 'Float', 'Long', 'Int', 'Short', 'Byte'])
+                ReifiedMatrices, ReifiedNDArrays)
     }
 }
 
@@ -462,32 +487,29 @@ def dtypeName(dtype) {
 
 def convertGetter(baseDtype, toDtype) {
     if(baseDtype == 'T')
-        return "    override fun get${toDtype}(vararg indices: Int): ${toDtype} {\n" +
-               "        val ele = getGeneric(*indices)\n" +
+        return "    override fun get${toDtype}(i: Int): ${toDtype} {\n" +
+               "        val ele = getGeneric(i)\n" +
                "        if (ele is ${toDtype})\n" +
                "            return ele\n" +
                "        else\n" +
                "            error(wrongType)\n" +
                "    }"
     else
-        return "    override fun get${toDtype}(vararg indices: Int): ${toDtype} {\n" +
-               "        checkIndices(indices)\n" +
-               "        val ele = storage[nIdxToLinear(indices)]\n" +
+        return "    override fun get${toDtype}(i: Int): ${toDtype} {\n" +
+               "        val ele = storage[checkLinearIndex(i)]\n" +
                "        return ele.to${toDtype}()\n" +
                "    }"
 }
 
 def convertSetter(baseDtype, toDtype) {
     if(baseDtype == 'T')
-        return "    override fun set${toDtype}(vararg indices: Int, value: ${toDtype}) {\n" +
-               "        setGeneric(indices=*indices, value=value as ${baseDtype})\n" +
-               "    }"
+        return "    override fun set${toDtype}(i: Int, value: ${toDtype}) {\n" +
+               "       setGeneric(i, value as ${baseDtype})\n" +
+               "    }\n"
     else
-        return "    override fun set${toDtype}(vararg indices: Int, value: ${toDtype}) {\n" +
-               "        checkIndices(indices)\n" +
-               "        storage[nIdxToLinear(indices)] = value.to${baseDtype}()\n" +
-               "    }"
-
+        return "    override fun set${toDtype}(i: Int, value: ${toDtype}) {\n" +
+               "        storage[checkLinearIndex(i)] = value.to${baseDtype}()\n" +
+               "    }\n"
 }
 
 def floatersOnly(dtype) {
@@ -587,6 +609,26 @@ def inline(dtype) {
     else {
         return ""
     }
+}
+
+def primitiveGetSet(types) {
+    types.findAll { it != "T" }.collect { """
+        @KomaJsName("get${it}ND")
+        fun get$it(vararg indices: Int) = get$it(safeIdxToLinear(indices))
+        @KomaJsName("get${it}1D")
+        fun get$it(i: Int): $it
+        @KomaJsName("set${it}ND")
+        fun set$it(vararg indices: Int, value: $it) = set$it(safeIdxToLinear(indices), value)
+        @KomaJsName("set${it}1D")
+        fun set$it(i: Int, v: $it)
+    """.stripIndent() }.join("\n")
+}
+
+def override1DPrimitiveGetSet(matrixTypes, ndTypes) {
+    (ndTypes - matrixTypes).collect { """
+        override fun get$it(i: Int): ${it} = getGeneric(i) as $it
+        override fun set$it(i: Int, value: $it) { setGeneric(i, value as T) }
+    """.stripIndent() }.join("\n")
 }
 
 apply from: 'buildscripts/publishing.gradle'

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -25,6 +25,17 @@ inline fun  NDArray<Byte>.fill(f: (idx: IntArray) -> Byte) = apply {
         this.setByte(linear, f(nd))
 }
 
+@koma.internal.JvmName("fillByteBoth")
+inline fun  NDArray<Byte>.fillBoth(f: (nd: IntArray, linear: Int) -> Byte) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setByte(linear, f(nd, linear))
+}
+
+@koma.internal.JvmName("fillByteLinear")
+inline fun  NDArray<Byte>.fillLinear(f: (idx: Int) -> Byte) = apply {
+    for (idx in 0 until size)
+        this.setByte(idx, f(idx))
+}
 
 @koma.internal.JvmName("createByte")
 inline fun  NumericalNDArrayFactory<Byte>.create(vararg lengths: Int, filler: (idx: IntArray) -> Byte)
@@ -39,13 +50,8 @@ inline fun  NumericalNDArrayFactory<Byte>.create(vararg lengths: Int, filler: (i
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapByte")
-inline fun  NDArray<Byte>.map(f: (Byte) -> Byte): NDArray<Byte> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(ele))
-    return out
-}
+inline fun  NDArray<Byte>.map(f: (Byte) -> Byte)
+    = NDArray.byteFactory.alloc(shape().toIntArray()).fillLinear { f(this.getByte(it)) }
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage
@@ -57,13 +63,8 @@ inline fun  NDArray<Byte>.map(f: (Byte) -> Byte): NDArray<Byte> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapIndexedByte")
-inline fun  NDArray<Byte>.mapIndexed(f: (idx: Int, ele: Byte) -> Byte): NDArray<Byte> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(idx, ele))
-    return out
-}
+inline fun  NDArray<Byte>.mapIndexed(f: (idx: Int, ele: Byte) -> Byte)
+    = NDArray.byteFactory.alloc(shape().toIntArray()).fillLinear { f(it, this.getByte(it)) }
 /**
  * Takes each element in a NDArray and passes them through f.
  *
@@ -72,8 +73,9 @@ inline fun  NDArray<Byte>.mapIndexed(f: (idx: Int, ele: Byte) -> Byte): NDArray<
  */
 @koma.internal.JvmName("forEachByte")
 inline fun  NDArray<Byte>.forEach(f: (ele: Byte) -> Unit) {
-    for (ele in this.toIterable())
-        f(ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(getByte(idx))
 }
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is a linear
@@ -85,11 +87,10 @@ inline fun  NDArray<Byte>.forEach(f: (ele: Byte) -> Unit) {
  */
 @koma.internal.JvmName("forEachIndexedByte")
 inline fun  NDArray<Byte>.forEachIndexed(f: (idx: Int, ele: Byte) -> Unit) {
-    for ((idx, ele) in this.toIterable().withIndex())
-        f(idx, ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(idx, getByte(idx))
 }
-
-// TODO: for both of these, batch compute [linearToNIdx] instead of computing for every ele
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -102,7 +103,7 @@ inline fun  NDArray<Byte>.forEachIndexed(f: (idx: Int, ele: Byte) -> Unit) {
  */
 @koma.internal.JvmName("mapIndexedNByte")
 inline fun  NDArray<Byte>.mapIndexedN(f: (idx: IntArray, ele: Byte) -> Byte): NDArray<Byte>
-        = this.mapIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+    = NDArray.byteFactory.alloc(shape().toIntArray()).fillBoth { nd, linear -> f(nd, getByte(linear)) }
 
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is the full
@@ -113,8 +114,10 @@ inline fun  NDArray<Byte>.mapIndexedN(f: (idx: IntArray, ele: Byte) -> Byte): ND
  *
  */
 @koma.internal.JvmName("forEachIndexedNByte")
-inline fun  NDArray<Byte>.forEachIndexedN(f: (idx: IntArray, ele: Byte) -> Unit)
-        = this.forEachIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+inline fun  NDArray<Byte>.forEachIndexedN(f: (idx: IntArray, ele: Byte) -> Unit) {
+    for ((nd, linear) in iterateIndices())
+        f(nd, getByte(linear))
+}
 
 
 @koma.internal.JvmName("getRangesByte")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -120,7 +120,7 @@ inline fun  NDArray<Byte>.forEachIndexedN(f: (idx: IntArray, ele: Byte) -> Unit)
 @koma.internal.JvmName("getRangesByte")
 operator fun  NDArray<Byte>.get(vararg indices: IntRange): NDArray<Byte> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Byte>(indices
+    return DefaultGenericNDArray<Byte>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -13,19 +13,22 @@ import koma.internal.default.utils.checkIndices
 import koma.internal.default.utils.linearToNIdx
 import koma.matrix.doubleFactory
 import koma.ndarray.NDArray
+import koma.ndarray.NumericalNDArrayFactory
 import koma.pow
 import koma.matrix.Matrix
 
 
 
 @koma.internal.JvmName("fillByte")
-inline fun  NDArray<Byte>.fill(f: (idx: IntArray) -> Byte): NDArray<Byte> {
-    this.forEachIndexedN { idx, ele ->
-        this.set(indices=*idx, value = f(idx))
-    }
-    return this
+inline fun  NDArray<Byte>.fill(f: (idx: IntArray) -> Byte) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setByte(linear, f(nd))
 }
 
+
+@koma.internal.JvmName("createByte")
+inline fun  NumericalNDArrayFactory<Byte>.create(vararg lengths: Int, filler: (idx: IntArray) -> Byte)
+    = alloc(lengths).fill(filler)
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -117,7 +120,7 @@ inline fun  NDArray<Byte>.forEachIndexedN(f: (idx: IntArray, ele: Byte) -> Unit)
 @koma.internal.JvmName("getRangesByte")
 operator fun  NDArray<Byte>.get(vararg indices: IntRange): NDArray<Byte> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Byte>(shape = *indices
+    return DefaultGenericNDArray<Byte>(indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }
@@ -139,13 +142,13 @@ operator fun  NDArray<Byte>.set(vararg indices: Int, value: NDArray<Byte>) {
     val offset = indices.map { it }.toIntArray()
     value.forEachIndexedN { idx, ele ->
         val newIdx = offset.zip(idx).map { it.first + it.second }.toIntArray()
-        this.setGeneric(indices=*newIdx, value=ele)
+        this.setGeneric(indices=*newIdx, v=ele)
     }
 }
 
 
 operator fun  NDArray<Byte>.get(vararg indices: Int) = getByte(*indices)
-operator fun  NDArray<Byte>.set(vararg indices: Int, value: Byte) = setByte(indices=*indices, value=value)
+operator fun  NDArray<Byte>.set(vararg indices: Int, value: Byte) = setByte(indices=*indices, v=value)
 
 
 @koma.internal.JvmName("divByte")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -13,6 +13,7 @@ import koma.internal.default.utils.checkIndices
 import koma.internal.default.utils.linearToNIdx
 import koma.matrix.doubleFactory
 import koma.ndarray.NDArray
+import koma.ndarray.NumericalNDArrayFactory
 import koma.pow
 import koma.matrix.Matrix
 
@@ -29,13 +30,15 @@ fun NDArray<Double>.toMatrix(): Matrix<Double> {
 }
 
 @koma.internal.JvmName("fillDouble")
-inline fun  NDArray<Double>.fill(f: (idx: IntArray) -> Double): NDArray<Double> {
-    this.forEachIndexedN { idx, ele ->
-        this.set(indices=*idx, value = f(idx))
-    }
-    return this
+inline fun  NDArray<Double>.fill(f: (idx: IntArray) -> Double) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setDouble(linear, f(nd))
 }
 
+
+@koma.internal.JvmName("createDouble")
+inline fun  NumericalNDArrayFactory<Double>.create(vararg lengths: Int, filler: (idx: IntArray) -> Double)
+    = alloc(lengths).fill(filler)
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -127,7 +130,7 @@ inline fun  NDArray<Double>.forEachIndexedN(f: (idx: IntArray, ele: Double) -> U
 @koma.internal.JvmName("getRangesDouble")
 operator fun  NDArray<Double>.get(vararg indices: IntRange): NDArray<Double> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Double>(shape = *indices
+    return DefaultGenericNDArray<Double>(indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }
@@ -149,13 +152,13 @@ operator fun  NDArray<Double>.set(vararg indices: Int, value: NDArray<Double>) {
     val offset = indices.map { it }.toIntArray()
     value.forEachIndexedN { idx, ele ->
         val newIdx = offset.zip(idx).map { it.first + it.second }.toIntArray()
-        this.setGeneric(indices=*newIdx, value=ele)
+        this.setGeneric(indices=*newIdx, v=ele)
     }
 }
 
 
 operator fun  NDArray<Double>.get(vararg indices: Int) = getDouble(*indices)
-operator fun  NDArray<Double>.set(vararg indices: Int, value: Double) = setDouble(indices=*indices, value=value)
+operator fun  NDArray<Double>.set(vararg indices: Int, value: Double) = setDouble(indices=*indices, v=value)
 
 
 @koma.internal.JvmName("divDouble")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -130,7 +130,7 @@ inline fun  NDArray<Double>.forEachIndexedN(f: (idx: IntArray, ele: Double) -> U
 @koma.internal.JvmName("getRangesDouble")
 operator fun  NDArray<Double>.get(vararg indices: IntRange): NDArray<Double> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Double>(indices
+    return DefaultGenericNDArray<Double>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -130,7 +130,7 @@ inline fun  NDArray<Float>.forEachIndexedN(f: (idx: IntArray, ele: Float) -> Uni
 @koma.internal.JvmName("getRangesFloat")
 operator fun  NDArray<Float>.get(vararg indices: IntRange): NDArray<Float> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Float>(indices
+    return DefaultGenericNDArray<Float>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -13,6 +13,7 @@ import koma.internal.default.utils.checkIndices
 import koma.internal.default.utils.linearToNIdx
 import koma.matrix.doubleFactory
 import koma.ndarray.NDArray
+import koma.ndarray.NumericalNDArrayFactory
 import koma.pow
 import koma.matrix.Matrix
 
@@ -29,13 +30,15 @@ fun NDArray<Float>.toMatrix(): Matrix<Float> {
 }
 
 @koma.internal.JvmName("fillFloat")
-inline fun  NDArray<Float>.fill(f: (idx: IntArray) -> Float): NDArray<Float> {
-    this.forEachIndexedN { idx, ele ->
-        this.set(indices=*idx, value = f(idx))
-    }
-    return this
+inline fun  NDArray<Float>.fill(f: (idx: IntArray) -> Float) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setFloat(linear, f(nd))
 }
 
+
+@koma.internal.JvmName("createFloat")
+inline fun  NumericalNDArrayFactory<Float>.create(vararg lengths: Int, filler: (idx: IntArray) -> Float)
+    = alloc(lengths).fill(filler)
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -127,7 +130,7 @@ inline fun  NDArray<Float>.forEachIndexedN(f: (idx: IntArray, ele: Float) -> Uni
 @koma.internal.JvmName("getRangesFloat")
 operator fun  NDArray<Float>.get(vararg indices: IntRange): NDArray<Float> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Float>(shape = *indices
+    return DefaultGenericNDArray<Float>(indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }
@@ -149,13 +152,13 @@ operator fun  NDArray<Float>.set(vararg indices: Int, value: NDArray<Float>) {
     val offset = indices.map { it }.toIntArray()
     value.forEachIndexedN { idx, ele ->
         val newIdx = offset.zip(idx).map { it.first + it.second }.toIntArray()
-        this.setGeneric(indices=*newIdx, value=ele)
+        this.setGeneric(indices=*newIdx, v=ele)
     }
 }
 
 
 operator fun  NDArray<Float>.get(vararg indices: Int) = getFloat(*indices)
-operator fun  NDArray<Float>.set(vararg indices: Int, value: Float) = setFloat(indices=*indices, value=value)
+operator fun  NDArray<Float>.set(vararg indices: Int, value: Float) = setFloat(indices=*indices, v=value)
 
 
 @koma.internal.JvmName("divFloat")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -35,6 +35,17 @@ inline fun  NDArray<Float>.fill(f: (idx: IntArray) -> Float) = apply {
         this.setFloat(linear, f(nd))
 }
 
+@koma.internal.JvmName("fillFloatBoth")
+inline fun  NDArray<Float>.fillBoth(f: (nd: IntArray, linear: Int) -> Float) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setFloat(linear, f(nd, linear))
+}
+
+@koma.internal.JvmName("fillFloatLinear")
+inline fun  NDArray<Float>.fillLinear(f: (idx: Int) -> Float) = apply {
+    for (idx in 0 until size)
+        this.setFloat(idx, f(idx))
+}
 
 @koma.internal.JvmName("createFloat")
 inline fun  NumericalNDArrayFactory<Float>.create(vararg lengths: Int, filler: (idx: IntArray) -> Float)
@@ -49,13 +60,8 @@ inline fun  NumericalNDArrayFactory<Float>.create(vararg lengths: Int, filler: (
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapFloat")
-inline fun  NDArray<Float>.map(f: (Float) -> Float): NDArray<Float> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(ele))
-    return out
-}
+inline fun  NDArray<Float>.map(f: (Float) -> Float)
+    = NDArray.floatFactory.alloc(shape().toIntArray()).fillLinear { f(this.getFloat(it)) }
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage
@@ -67,13 +73,8 @@ inline fun  NDArray<Float>.map(f: (Float) -> Float): NDArray<Float> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapIndexedFloat")
-inline fun  NDArray<Float>.mapIndexed(f: (idx: Int, ele: Float) -> Float): NDArray<Float> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(idx, ele))
-    return out
-}
+inline fun  NDArray<Float>.mapIndexed(f: (idx: Int, ele: Float) -> Float)
+    = NDArray.floatFactory.alloc(shape().toIntArray()).fillLinear { f(it, this.getFloat(it)) }
 /**
  * Takes each element in a NDArray and passes them through f.
  *
@@ -82,8 +83,9 @@ inline fun  NDArray<Float>.mapIndexed(f: (idx: Int, ele: Float) -> Float): NDArr
  */
 @koma.internal.JvmName("forEachFloat")
 inline fun  NDArray<Float>.forEach(f: (ele: Float) -> Unit) {
-    for (ele in this.toIterable())
-        f(ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(getFloat(idx))
 }
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is a linear
@@ -95,11 +97,10 @@ inline fun  NDArray<Float>.forEach(f: (ele: Float) -> Unit) {
  */
 @koma.internal.JvmName("forEachIndexedFloat")
 inline fun  NDArray<Float>.forEachIndexed(f: (idx: Int, ele: Float) -> Unit) {
-    for ((idx, ele) in this.toIterable().withIndex())
-        f(idx, ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(idx, getFloat(idx))
 }
-
-// TODO: for both of these, batch compute [linearToNIdx] instead of computing for every ele
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -112,7 +113,7 @@ inline fun  NDArray<Float>.forEachIndexed(f: (idx: Int, ele: Float) -> Unit) {
  */
 @koma.internal.JvmName("mapIndexedNFloat")
 inline fun  NDArray<Float>.mapIndexedN(f: (idx: IntArray, ele: Float) -> Float): NDArray<Float>
-        = this.mapIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+    = NDArray.floatFactory.alloc(shape().toIntArray()).fillBoth { nd, linear -> f(nd, getFloat(linear)) }
 
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is the full
@@ -123,8 +124,10 @@ inline fun  NDArray<Float>.mapIndexedN(f: (idx: IntArray, ele: Float) -> Float):
  *
  */
 @koma.internal.JvmName("forEachIndexedNFloat")
-inline fun  NDArray<Float>.forEachIndexedN(f: (idx: IntArray, ele: Float) -> Unit)
-        = this.forEachIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+inline fun  NDArray<Float>.forEachIndexedN(f: (idx: IntArray, ele: Float) -> Unit) {
+    for ((nd, linear) in iterateIndices())
+        f(nd, getFloat(linear))
+}
 
 
 @koma.internal.JvmName("getRangesFloat")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -131,7 +131,7 @@ fun <T> NDArray<T>.forEachIndexedN(f: (idx: IntArray, ele: T) -> Unit)
 @koma.internal.JvmName("getRangesGeneric")
 operator fun <T> NDArray<T>.get(vararg indices: IntRange): NDArray<T> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<T>(indices
+    return DefaultGenericNDArray<T>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -13,6 +13,7 @@ import koma.internal.default.utils.checkIndices
 import koma.internal.default.utils.linearToNIdx
 import koma.matrix.doubleFactory
 import koma.ndarray.NDArray
+import koma.ndarray.NumericalNDArrayFactory
 import koma.pow
 import koma.matrix.Matrix
 
@@ -29,13 +30,15 @@ fun NDArray<Int>.toMatrix(): Matrix<Int> {
 }
 
 @koma.internal.JvmName("fillInt")
-inline fun  NDArray<Int>.fill(f: (idx: IntArray) -> Int): NDArray<Int> {
-    this.forEachIndexedN { idx, ele ->
-        this.set(indices=*idx, value = f(idx))
-    }
-    return this
+inline fun  NDArray<Int>.fill(f: (idx: IntArray) -> Int) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setInt(linear, f(nd))
 }
 
+
+@koma.internal.JvmName("createInt")
+inline fun  NumericalNDArrayFactory<Int>.create(vararg lengths: Int, filler: (idx: IntArray) -> Int)
+    = alloc(lengths).fill(filler)
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -127,7 +130,7 @@ inline fun  NDArray<Int>.forEachIndexedN(f: (idx: IntArray, ele: Int) -> Unit)
 @koma.internal.JvmName("getRangesInt")
 operator fun  NDArray<Int>.get(vararg indices: IntRange): NDArray<Int> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Int>(shape = *indices
+    return DefaultGenericNDArray<Int>(indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }
@@ -149,13 +152,13 @@ operator fun  NDArray<Int>.set(vararg indices: Int, value: NDArray<Int>) {
     val offset = indices.map { it }.toIntArray()
     value.forEachIndexedN { idx, ele ->
         val newIdx = offset.zip(idx).map { it.first + it.second }.toIntArray()
-        this.setGeneric(indices=*newIdx, value=ele)
+        this.setGeneric(indices=*newIdx, v=ele)
     }
 }
 
 
 operator fun  NDArray<Int>.get(vararg indices: Int) = getInt(*indices)
-operator fun  NDArray<Int>.set(vararg indices: Int, value: Int) = setInt(indices=*indices, value=value)
+operator fun  NDArray<Int>.set(vararg indices: Int, value: Int) = setInt(indices=*indices, v=value)
 
 
 @koma.internal.JvmName("divInt")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -35,6 +35,17 @@ inline fun  NDArray<Int>.fill(f: (idx: IntArray) -> Int) = apply {
         this.setInt(linear, f(nd))
 }
 
+@koma.internal.JvmName("fillIntBoth")
+inline fun  NDArray<Int>.fillBoth(f: (nd: IntArray, linear: Int) -> Int) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setInt(linear, f(nd, linear))
+}
+
+@koma.internal.JvmName("fillIntLinear")
+inline fun  NDArray<Int>.fillLinear(f: (idx: Int) -> Int) = apply {
+    for (idx in 0 until size)
+        this.setInt(idx, f(idx))
+}
 
 @koma.internal.JvmName("createInt")
 inline fun  NumericalNDArrayFactory<Int>.create(vararg lengths: Int, filler: (idx: IntArray) -> Int)
@@ -49,13 +60,8 @@ inline fun  NumericalNDArrayFactory<Int>.create(vararg lengths: Int, filler: (id
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapInt")
-inline fun  NDArray<Int>.map(f: (Int) -> Int): NDArray<Int> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(ele))
-    return out
-}
+inline fun  NDArray<Int>.map(f: (Int) -> Int)
+    = NDArray.intFactory.alloc(shape().toIntArray()).fillLinear { f(this.getInt(it)) }
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage
@@ -67,13 +73,8 @@ inline fun  NDArray<Int>.map(f: (Int) -> Int): NDArray<Int> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapIndexedInt")
-inline fun  NDArray<Int>.mapIndexed(f: (idx: Int, ele: Int) -> Int): NDArray<Int> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(idx, ele))
-    return out
-}
+inline fun  NDArray<Int>.mapIndexed(f: (idx: Int, ele: Int) -> Int)
+    = NDArray.intFactory.alloc(shape().toIntArray()).fillLinear { f(it, this.getInt(it)) }
 /**
  * Takes each element in a NDArray and passes them through f.
  *
@@ -82,8 +83,9 @@ inline fun  NDArray<Int>.mapIndexed(f: (idx: Int, ele: Int) -> Int): NDArray<Int
  */
 @koma.internal.JvmName("forEachInt")
 inline fun  NDArray<Int>.forEach(f: (ele: Int) -> Unit) {
-    for (ele in this.toIterable())
-        f(ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(getInt(idx))
 }
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is a linear
@@ -95,11 +97,10 @@ inline fun  NDArray<Int>.forEach(f: (ele: Int) -> Unit) {
  */
 @koma.internal.JvmName("forEachIndexedInt")
 inline fun  NDArray<Int>.forEachIndexed(f: (idx: Int, ele: Int) -> Unit) {
-    for ((idx, ele) in this.toIterable().withIndex())
-        f(idx, ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(idx, getInt(idx))
 }
-
-// TODO: for both of these, batch compute [linearToNIdx] instead of computing for every ele
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -112,7 +113,7 @@ inline fun  NDArray<Int>.forEachIndexed(f: (idx: Int, ele: Int) -> Unit) {
  */
 @koma.internal.JvmName("mapIndexedNInt")
 inline fun  NDArray<Int>.mapIndexedN(f: (idx: IntArray, ele: Int) -> Int): NDArray<Int>
-        = this.mapIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+    = NDArray.intFactory.alloc(shape().toIntArray()).fillBoth { nd, linear -> f(nd, getInt(linear)) }
 
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is the full
@@ -123,8 +124,10 @@ inline fun  NDArray<Int>.mapIndexedN(f: (idx: IntArray, ele: Int) -> Int): NDArr
  *
  */
 @koma.internal.JvmName("forEachIndexedNInt")
-inline fun  NDArray<Int>.forEachIndexedN(f: (idx: IntArray, ele: Int) -> Unit)
-        = this.forEachIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+inline fun  NDArray<Int>.forEachIndexedN(f: (idx: IntArray, ele: Int) -> Unit) {
+    for ((nd, linear) in iterateIndices())
+        f(nd, getInt(linear))
+}
 
 
 @koma.internal.JvmName("getRangesInt")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -130,7 +130,7 @@ inline fun  NDArray<Int>.forEachIndexedN(f: (idx: IntArray, ele: Int) -> Unit)
 @koma.internal.JvmName("getRangesInt")
 operator fun  NDArray<Int>.get(vararg indices: IntRange): NDArray<Int> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Int>(indices
+    return DefaultGenericNDArray<Int>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -13,19 +13,22 @@ import koma.internal.default.utils.checkIndices
 import koma.internal.default.utils.linearToNIdx
 import koma.matrix.doubleFactory
 import koma.ndarray.NDArray
+import koma.ndarray.NumericalNDArrayFactory
 import koma.pow
 import koma.matrix.Matrix
 
 
 
 @koma.internal.JvmName("fillLong")
-inline fun  NDArray<Long>.fill(f: (idx: IntArray) -> Long): NDArray<Long> {
-    this.forEachIndexedN { idx, ele ->
-        this.set(indices=*idx, value = f(idx))
-    }
-    return this
+inline fun  NDArray<Long>.fill(f: (idx: IntArray) -> Long) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setLong(linear, f(nd))
 }
 
+
+@koma.internal.JvmName("createLong")
+inline fun  NumericalNDArrayFactory<Long>.create(vararg lengths: Int, filler: (idx: IntArray) -> Long)
+    = alloc(lengths).fill(filler)
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -117,7 +120,7 @@ inline fun  NDArray<Long>.forEachIndexedN(f: (idx: IntArray, ele: Long) -> Unit)
 @koma.internal.JvmName("getRangesLong")
 operator fun  NDArray<Long>.get(vararg indices: IntRange): NDArray<Long> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Long>(shape = *indices
+    return DefaultGenericNDArray<Long>(indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }
@@ -139,13 +142,13 @@ operator fun  NDArray<Long>.set(vararg indices: Int, value: NDArray<Long>) {
     val offset = indices.map { it }.toIntArray()
     value.forEachIndexedN { idx, ele ->
         val newIdx = offset.zip(idx).map { it.first + it.second }.toIntArray()
-        this.setGeneric(indices=*newIdx, value=ele)
+        this.setGeneric(indices=*newIdx, v=ele)
     }
 }
 
 
 operator fun  NDArray<Long>.get(vararg indices: Int) = getLong(*indices)
-operator fun  NDArray<Long>.set(vararg indices: Int, value: Long) = setLong(indices=*indices, value=value)
+operator fun  NDArray<Long>.set(vararg indices: Int, value: Long) = setLong(indices=*indices, v=value)
 
 
 @koma.internal.JvmName("divLong")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -120,7 +120,7 @@ inline fun  NDArray<Long>.forEachIndexedN(f: (idx: IntArray, ele: Long) -> Unit)
 @koma.internal.JvmName("getRangesLong")
 operator fun  NDArray<Long>.get(vararg indices: IntRange): NDArray<Long> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Long>(indices
+    return DefaultGenericNDArray<Long>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -25,6 +25,17 @@ inline fun  NDArray<Long>.fill(f: (idx: IntArray) -> Long) = apply {
         this.setLong(linear, f(nd))
 }
 
+@koma.internal.JvmName("fillLongBoth")
+inline fun  NDArray<Long>.fillBoth(f: (nd: IntArray, linear: Int) -> Long) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setLong(linear, f(nd, linear))
+}
+
+@koma.internal.JvmName("fillLongLinear")
+inline fun  NDArray<Long>.fillLinear(f: (idx: Int) -> Long) = apply {
+    for (idx in 0 until size)
+        this.setLong(idx, f(idx))
+}
 
 @koma.internal.JvmName("createLong")
 inline fun  NumericalNDArrayFactory<Long>.create(vararg lengths: Int, filler: (idx: IntArray) -> Long)
@@ -39,13 +50,8 @@ inline fun  NumericalNDArrayFactory<Long>.create(vararg lengths: Int, filler: (i
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapLong")
-inline fun  NDArray<Long>.map(f: (Long) -> Long): NDArray<Long> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(ele))
-    return out
-}
+inline fun  NDArray<Long>.map(f: (Long) -> Long)
+    = NDArray.longFactory.alloc(shape().toIntArray()).fillLinear { f(this.getLong(it)) }
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage
@@ -57,13 +63,8 @@ inline fun  NDArray<Long>.map(f: (Long) -> Long): NDArray<Long> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapIndexedLong")
-inline fun  NDArray<Long>.mapIndexed(f: (idx: Int, ele: Long) -> Long): NDArray<Long> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(idx, ele))
-    return out
-}
+inline fun  NDArray<Long>.mapIndexed(f: (idx: Int, ele: Long) -> Long)
+    = NDArray.longFactory.alloc(shape().toIntArray()).fillLinear { f(it, this.getLong(it)) }
 /**
  * Takes each element in a NDArray and passes them through f.
  *
@@ -72,8 +73,9 @@ inline fun  NDArray<Long>.mapIndexed(f: (idx: Int, ele: Long) -> Long): NDArray<
  */
 @koma.internal.JvmName("forEachLong")
 inline fun  NDArray<Long>.forEach(f: (ele: Long) -> Unit) {
-    for (ele in this.toIterable())
-        f(ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(getLong(idx))
 }
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is a linear
@@ -85,11 +87,10 @@ inline fun  NDArray<Long>.forEach(f: (ele: Long) -> Unit) {
  */
 @koma.internal.JvmName("forEachIndexedLong")
 inline fun  NDArray<Long>.forEachIndexed(f: (idx: Int, ele: Long) -> Unit) {
-    for ((idx, ele) in this.toIterable().withIndex())
-        f(idx, ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(idx, getLong(idx))
 }
-
-// TODO: for both of these, batch compute [linearToNIdx] instead of computing for every ele
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -102,7 +103,7 @@ inline fun  NDArray<Long>.forEachIndexed(f: (idx: Int, ele: Long) -> Unit) {
  */
 @koma.internal.JvmName("mapIndexedNLong")
 inline fun  NDArray<Long>.mapIndexedN(f: (idx: IntArray, ele: Long) -> Long): NDArray<Long>
-        = this.mapIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+    = NDArray.longFactory.alloc(shape().toIntArray()).fillBoth { nd, linear -> f(nd, getLong(linear)) }
 
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is the full
@@ -113,8 +114,10 @@ inline fun  NDArray<Long>.mapIndexedN(f: (idx: IntArray, ele: Long) -> Long): ND
  *
  */
 @koma.internal.JvmName("forEachIndexedNLong")
-inline fun  NDArray<Long>.forEachIndexedN(f: (idx: IntArray, ele: Long) -> Unit)
-        = this.forEachIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+inline fun  NDArray<Long>.forEachIndexedN(f: (idx: IntArray, ele: Long) -> Unit) {
+    for ((nd, linear) in iterateIndices())
+        f(nd, getLong(linear))
+}
 
 
 @koma.internal.JvmName("getRangesLong")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -13,19 +13,22 @@ import koma.internal.default.utils.checkIndices
 import koma.internal.default.utils.linearToNIdx
 import koma.matrix.doubleFactory
 import koma.ndarray.NDArray
+import koma.ndarray.NumericalNDArrayFactory
 import koma.pow
 import koma.matrix.Matrix
 
 
 
 @koma.internal.JvmName("fillShort")
-inline fun  NDArray<Short>.fill(f: (idx: IntArray) -> Short): NDArray<Short> {
-    this.forEachIndexedN { idx, ele ->
-        this.set(indices=*idx, value = f(idx))
-    }
-    return this
+inline fun  NDArray<Short>.fill(f: (idx: IntArray) -> Short) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setShort(linear, f(nd))
 }
 
+
+@koma.internal.JvmName("createShort")
+inline fun  NumericalNDArrayFactory<Short>.create(vararg lengths: Int, filler: (idx: IntArray) -> Short)
+    = alloc(lengths).fill(filler)
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -117,7 +120,7 @@ inline fun  NDArray<Short>.forEachIndexedN(f: (idx: IntArray, ele: Short) -> Uni
 @koma.internal.JvmName("getRangesShort")
 operator fun  NDArray<Short>.get(vararg indices: IntRange): NDArray<Short> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Short>(shape = *indices
+    return DefaultGenericNDArray<Short>(indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }
@@ -139,13 +142,13 @@ operator fun  NDArray<Short>.set(vararg indices: Int, value: NDArray<Short>) {
     val offset = indices.map { it }.toIntArray()
     value.forEachIndexedN { idx, ele ->
         val newIdx = offset.zip(idx).map { it.first + it.second }.toIntArray()
-        this.setGeneric(indices=*newIdx, value=ele)
+        this.setGeneric(indices=*newIdx, v=ele)
     }
 }
 
 
 operator fun  NDArray<Short>.get(vararg indices: Int) = getShort(*indices)
-operator fun  NDArray<Short>.set(vararg indices: Int, value: Short) = setShort(indices=*indices, value=value)
+operator fun  NDArray<Short>.set(vararg indices: Int, value: Short) = setShort(indices=*indices, v=value)
 
 
 @koma.internal.JvmName("divShort")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -25,6 +25,17 @@ inline fun  NDArray<Short>.fill(f: (idx: IntArray) -> Short) = apply {
         this.setShort(linear, f(nd))
 }
 
+@koma.internal.JvmName("fillShortBoth")
+inline fun  NDArray<Short>.fillBoth(f: (nd: IntArray, linear: Int) -> Short) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.setShort(linear, f(nd, linear))
+}
+
+@koma.internal.JvmName("fillShortLinear")
+inline fun  NDArray<Short>.fillLinear(f: (idx: Int) -> Short) = apply {
+    for (idx in 0 until size)
+        this.setShort(idx, f(idx))
+}
 
 @koma.internal.JvmName("createShort")
 inline fun  NumericalNDArrayFactory<Short>.create(vararg lengths: Int, filler: (idx: IntArray) -> Short)
@@ -39,13 +50,8 @@ inline fun  NumericalNDArrayFactory<Short>.create(vararg lengths: Int, filler: (
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapShort")
-inline fun  NDArray<Short>.map(f: (Short) -> Short): NDArray<Short> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(ele))
-    return out
-}
+inline fun  NDArray<Short>.map(f: (Short) -> Short)
+    = NDArray.shortFactory.alloc(shape().toIntArray()).fillLinear { f(this.getShort(it)) }
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage
@@ -57,13 +63,8 @@ inline fun  NDArray<Short>.map(f: (Short) -> Short): NDArray<Short> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapIndexedShort")
-inline fun  NDArray<Short>.mapIndexed(f: (idx: Int, ele: Short) -> Short): NDArray<Short> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(idx, ele))
-    return out
-}
+inline fun  NDArray<Short>.mapIndexed(f: (idx: Int, ele: Short) -> Short)
+    = NDArray.shortFactory.alloc(shape().toIntArray()).fillLinear { f(it, this.getShort(it)) }
 /**
  * Takes each element in a NDArray and passes them through f.
  *
@@ -72,8 +73,9 @@ inline fun  NDArray<Short>.mapIndexed(f: (idx: Int, ele: Short) -> Short): NDArr
  */
 @koma.internal.JvmName("forEachShort")
 inline fun  NDArray<Short>.forEach(f: (ele: Short) -> Unit) {
-    for (ele in this.toIterable())
-        f(ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(getShort(idx))
 }
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is a linear
@@ -85,11 +87,10 @@ inline fun  NDArray<Short>.forEach(f: (ele: Short) -> Unit) {
  */
 @koma.internal.JvmName("forEachIndexedShort")
 inline fun  NDArray<Short>.forEachIndexed(f: (idx: Int, ele: Short) -> Unit) {
-    for ((idx, ele) in this.toIterable().withIndex())
-        f(idx, ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(idx, getShort(idx))
 }
-
-// TODO: for both of these, batch compute [linearToNIdx] instead of computing for every ele
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -102,7 +103,7 @@ inline fun  NDArray<Short>.forEachIndexed(f: (idx: Int, ele: Short) -> Unit) {
  */
 @koma.internal.JvmName("mapIndexedNShort")
 inline fun  NDArray<Short>.mapIndexedN(f: (idx: IntArray, ele: Short) -> Short): NDArray<Short>
-        = this.mapIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+    = NDArray.shortFactory.alloc(shape().toIntArray()).fillBoth { nd, linear -> f(nd, getShort(linear)) }
 
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is the full
@@ -113,8 +114,10 @@ inline fun  NDArray<Short>.mapIndexedN(f: (idx: IntArray, ele: Short) -> Short):
  *
  */
 @koma.internal.JvmName("forEachIndexedNShort")
-inline fun  NDArray<Short>.forEachIndexedN(f: (idx: IntArray, ele: Short) -> Unit)
-        = this.forEachIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+inline fun  NDArray<Short>.forEachIndexedN(f: (idx: IntArray, ele: Short) -> Unit) {
+    for ((nd, linear) in iterateIndices())
+        f(nd, getShort(linear))
+}
 
 
 @koma.internal.JvmName("getRangesShort")

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -120,7 +120,7 @@ inline fun  NDArray<Short>.forEachIndexedN(f: (idx: IntArray, ele: Short) -> Uni
 @koma.internal.JvmName("getRangesShort")
 operator fun  NDArray<Short>.get(vararg indices: IntRange): NDArray<Short> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<Short>(indices
+    return DefaultGenericNDArray<Short>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
@@ -37,8 +37,8 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): Byte = storage[index]
-    override fun setLinear(index: Int, value: Byte) { storage[index] = value }
+    override fun getGeneric(i: Int): Byte = storage[i]
+    override fun setGeneric(i: Int, value: Byte) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: Byte) {
         checkIndices(indices)
@@ -51,60 +51,54 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+    override fun getDouble(i: Int): Double {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toByte()
+    override fun setDouble(i: Int, value: Double) {
+        storage[checkLinearIndex(i)] = value.toByte()
     }
-    override fun getByte(vararg indices: Int): Byte {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getByte(i: Int): Byte {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toByte()
+    override fun setByte(i: Int, value: Byte) {
+        storage[checkLinearIndex(i)] = value.toByte()
     }
-    override fun getInt(vararg indices: Int): Int {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getInt(i: Int): Int {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toByte()
+    override fun setInt(i: Int, value: Int) {
+        storage[checkLinearIndex(i)] = value.toByte()
     }
-    override fun getFloat(vararg indices: Int): Float {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getFloat(i: Int): Float {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toByte()
+    override fun setFloat(i: Int, value: Float) {
+        storage[checkLinearIndex(i)] = value.toByte()
     }
-    override fun getLong(vararg indices: Int): Long {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getLong(i: Int): Long {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toByte()
+    override fun setLong(i: Int, value: Long) {
+        storage[checkLinearIndex(i)] = value.toByte()
     }
-    override fun getShort(vararg indices: Int): Short {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getShort(i: Int): Short {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toByte()
+    override fun setShort(i: Int, value: Short) {
+        storage[checkLinearIndex(i)] = value.toByte()
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
@@ -45,6 +45,7 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<Byte> = DefaultByteNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultByteNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->Byte)? = null): NDArray<Byte> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Byte)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +50,7 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Byte> = DefaultByteNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Byte> = DefaultByteNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,48 +58,48 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
         val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(i: Int, value: Double) {
-        storage[checkLinearIndex(i)] = value.toByte()
+    override fun setDouble(i: Int, v: Double) {
+        storage[checkLinearIndex(i)] = v.toByte()
     }
 
     override fun getByte(i: Int): Byte {
         val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(i: Int, value: Byte) {
-        storage[checkLinearIndex(i)] = value.toByte()
+    override fun setByte(i: Int, v: Byte) {
+        storage[checkLinearIndex(i)] = v.toByte()
     }
 
     override fun getInt(i: Int): Int {
         val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(i: Int, value: Int) {
-        storage[checkLinearIndex(i)] = value.toByte()
+    override fun setInt(i: Int, v: Int) {
+        storage[checkLinearIndex(i)] = v.toByte()
     }
 
     override fun getFloat(i: Int): Float {
         val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(i: Int, value: Float) {
-        storage[checkLinearIndex(i)] = value.toByte()
+    override fun setFloat(i: Int, v: Float) {
+        storage[checkLinearIndex(i)] = v.toByte()
     }
 
     override fun getLong(i: Int): Long {
         val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(i: Int, value: Long) {
-        storage[checkLinearIndex(i)] = value.toByte()
+    override fun setLong(i: Int, v: Long) {
+        storage[checkLinearIndex(i)] = v.toByte()
     }
 
     override fun getShort(i: Int): Short {
         val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(i: Int, value: Short) {
-        storage[checkLinearIndex(i)] = value.toByte()
+    override fun setShort(i: Int, v: Short) {
+        storage[checkLinearIndex(i)] = v.toByte()
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultByteNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->Byte)? = null): NDArray<Byte> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Byte)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -50,7 +47,7 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") protected val shape: 
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Byte> = DefaultByteNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Byte> = DefaultByteNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultByteNDArrayFactory: NumericalNDArrayFactory<Byte> {
-    override fun alloc(lengths: IntArray) = DefaultByteNDArray(lengths)
+    override fun alloc(lengths: IntArray) = DefaultByteNDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.toByte() }
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultByteNDArrayFactory: NumericalNDArrayFactory<Byte> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> Byte): NDArray<Byte> {
-        return DefaultByteNDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = DefaultByteNDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<Byte> {
-        return DefaultByteNDArray(*lengths).fill {
-            0.toByte()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.toByte() }
 
-    override fun ones(vararg lengths: Int): NDArray<Byte> {
-        return DefaultByteNDArray(*lengths).fill {
-            1.toByte()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.toByte() }
 
-    override fun rand(vararg lengths: Int): NDArray<Byte> {
-        return DefaultByteNDArray(*lengths).fill {
-            0.toByte()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.toByte() }
 
-    override fun randn(vararg lengths: Int): NDArray<Byte> {
-        return DefaultByteNDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().toByte()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toByte()
     }
-
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArrayFactory.kt
@@ -15,9 +15,11 @@ class DefaultByteNDArrayFactory: NumericalNDArrayFactory<Byte> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.toByte() }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.toByte() }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toByte()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().toByte()
+        koma.internal.getRng().nextGaussian().toByte()
     }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
@@ -45,6 +45,7 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<Double> = DefaultDoubleNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultDoubleNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->Double)? = null): NDArray<Double> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Double)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -50,7 +47,7 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") protected val shape
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Double> = DefaultDoubleNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Double> = DefaultDoubleNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultDoubleNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->Double)? = null): NDArray<Double> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Double)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +50,7 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Double> = DefaultDoubleNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Double> = DefaultDoubleNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,48 +58,48 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
         val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(i: Int, value: Double) {
-        storage[checkLinearIndex(i)] = value.toDouble()
+    override fun setDouble(i: Int, v: Double) {
+        storage[checkLinearIndex(i)] = v.toDouble()
     }
 
     override fun getByte(i: Int): Byte {
         val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(i: Int, value: Byte) {
-        storage[checkLinearIndex(i)] = value.toDouble()
+    override fun setByte(i: Int, v: Byte) {
+        storage[checkLinearIndex(i)] = v.toDouble()
     }
 
     override fun getInt(i: Int): Int {
         val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(i: Int, value: Int) {
-        storage[checkLinearIndex(i)] = value.toDouble()
+    override fun setInt(i: Int, v: Int) {
+        storage[checkLinearIndex(i)] = v.toDouble()
     }
 
     override fun getFloat(i: Int): Float {
         val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(i: Int, value: Float) {
-        storage[checkLinearIndex(i)] = value.toDouble()
+    override fun setFloat(i: Int, v: Float) {
+        storage[checkLinearIndex(i)] = v.toDouble()
     }
 
     override fun getLong(i: Int): Long {
         val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(i: Int, value: Long) {
-        storage[checkLinearIndex(i)] = value.toDouble()
+    override fun setLong(i: Int, v: Long) {
+        storage[checkLinearIndex(i)] = v.toDouble()
     }
 
     override fun getShort(i: Int): Short {
         val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(i: Int, value: Short) {
-        storage[checkLinearIndex(i)] = value.toDouble()
+    override fun setShort(i: Int, v: Short) {
+        storage[checkLinearIndex(i)] = v.toDouble()
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
@@ -37,8 +37,8 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): Double = storage[index]
-    override fun setLinear(index: Int, value: Double) { storage[index] = value }
+    override fun getGeneric(i: Int): Double = storage[i]
+    override fun setGeneric(i: Int, value: Double) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: Double) {
         checkIndices(indices)
@@ -51,60 +51,54 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+    override fun getDouble(i: Int): Double {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toDouble()
+    override fun setDouble(i: Int, value: Double) {
+        storage[checkLinearIndex(i)] = value.toDouble()
     }
-    override fun getByte(vararg indices: Int): Byte {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getByte(i: Int): Byte {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toDouble()
+    override fun setByte(i: Int, value: Byte) {
+        storage[checkLinearIndex(i)] = value.toDouble()
     }
-    override fun getInt(vararg indices: Int): Int {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getInt(i: Int): Int {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toDouble()
+    override fun setInt(i: Int, value: Int) {
+        storage[checkLinearIndex(i)] = value.toDouble()
     }
-    override fun getFloat(vararg indices: Int): Float {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getFloat(i: Int): Float {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toDouble()
+    override fun setFloat(i: Int, value: Float) {
+        storage[checkLinearIndex(i)] = value.toDouble()
     }
-    override fun getLong(vararg indices: Int): Long {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getLong(i: Int): Long {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toDouble()
+    override fun setLong(i: Int, value: Long) {
+        storage[checkLinearIndex(i)] = value.toDouble()
     }
-    override fun getShort(vararg indices: Int): Short {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getShort(i: Int): Short {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toDouble()
+    override fun setShort(i: Int, value: Short) {
+        storage[checkLinearIndex(i)] = value.toDouble()
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultDoubleNDArrayFactory: NumericalNDArrayFactory<Double> {
-    override fun alloc(lengths: IntArray) = DefaultDoubleNDArray(lengths)
+    override fun alloc(lengths: IntArray) = DefaultDoubleNDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.0 }
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultDoubleNDArrayFactory: NumericalNDArrayFactory<Double> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> Double): NDArray<Double> {
-        return DefaultDoubleNDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = DefaultDoubleNDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<Double> {
-        return DefaultDoubleNDArray(*lengths).fill {
-            0.toDouble()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.0 }
 
-    override fun ones(vararg lengths: Int): NDArray<Double> {
-        return DefaultDoubleNDArray(*lengths).fill {
-            1.toDouble()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.0 }
 
-    override fun rand(vararg lengths: Int): NDArray<Double> {
-        return DefaultDoubleNDArray(*lengths).fill {
-            0.toDouble()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.0 }
 
-    override fun randn(vararg lengths: Int): NDArray<Double> {
-        return DefaultDoubleNDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().toDouble()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toDouble()
     }
-
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArrayFactory.kt
@@ -15,9 +15,11 @@ class DefaultDoubleNDArrayFactory: NumericalNDArrayFactory<Double> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.0 }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.0 }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toDouble()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().toDouble()
+        koma.internal.getRng().nextGaussian().toDouble()
     }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
@@ -37,8 +37,8 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): Float = storage[index]
-    override fun setLinear(index: Int, value: Float) { storage[index] = value }
+    override fun getGeneric(i: Int): Float = storage[i]
+    override fun setGeneric(i: Int, value: Float) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: Float) {
         checkIndices(indices)
@@ -51,60 +51,54 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+    override fun getDouble(i: Int): Double {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toFloat()
+    override fun setDouble(i: Int, value: Double) {
+        storage[checkLinearIndex(i)] = value.toFloat()
     }
-    override fun getByte(vararg indices: Int): Byte {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getByte(i: Int): Byte {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toFloat()
+    override fun setByte(i: Int, value: Byte) {
+        storage[checkLinearIndex(i)] = value.toFloat()
     }
-    override fun getInt(vararg indices: Int): Int {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getInt(i: Int): Int {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toFloat()
+    override fun setInt(i: Int, value: Int) {
+        storage[checkLinearIndex(i)] = value.toFloat()
     }
-    override fun getFloat(vararg indices: Int): Float {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getFloat(i: Int): Float {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toFloat()
+    override fun setFloat(i: Int, value: Float) {
+        storage[checkLinearIndex(i)] = value.toFloat()
     }
-    override fun getLong(vararg indices: Int): Long {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getLong(i: Int): Long {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toFloat()
+    override fun setLong(i: Int, value: Long) {
+        storage[checkLinearIndex(i)] = value.toFloat()
     }
-    override fun getShort(vararg indices: Int): Short {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getShort(i: Int): Short {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toFloat()
+    override fun setShort(i: Int, value: Short) {
+        storage[checkLinearIndex(i)] = value.toFloat()
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultFloatNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->Float)? = null): NDArray<Float> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Float)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +50,7 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Float> = DefaultFloatNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Float> = DefaultFloatNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,48 +58,48 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
         val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(i: Int, value: Double) {
-        storage[checkLinearIndex(i)] = value.toFloat()
+    override fun setDouble(i: Int, v: Double) {
+        storage[checkLinearIndex(i)] = v.toFloat()
     }
 
     override fun getByte(i: Int): Byte {
         val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(i: Int, value: Byte) {
-        storage[checkLinearIndex(i)] = value.toFloat()
+    override fun setByte(i: Int, v: Byte) {
+        storage[checkLinearIndex(i)] = v.toFloat()
     }
 
     override fun getInt(i: Int): Int {
         val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(i: Int, value: Int) {
-        storage[checkLinearIndex(i)] = value.toFloat()
+    override fun setInt(i: Int, v: Int) {
+        storage[checkLinearIndex(i)] = v.toFloat()
     }
 
     override fun getFloat(i: Int): Float {
         val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(i: Int, value: Float) {
-        storage[checkLinearIndex(i)] = value.toFloat()
+    override fun setFloat(i: Int, v: Float) {
+        storage[checkLinearIndex(i)] = v.toFloat()
     }
 
     override fun getLong(i: Int): Long {
         val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(i: Int, value: Long) {
-        storage[checkLinearIndex(i)] = value.toFloat()
+    override fun setLong(i: Int, v: Long) {
+        storage[checkLinearIndex(i)] = v.toFloat()
     }
 
     override fun getShort(i: Int): Short {
         val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(i: Int, value: Short) {
-        storage[checkLinearIndex(i)] = value.toFloat()
+    override fun setShort(i: Int, v: Short) {
+        storage[checkLinearIndex(i)] = v.toFloat()
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
@@ -45,6 +45,7 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<Float> = DefaultFloatNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultFloatNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->Float)? = null): NDArray<Float> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Float)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -50,7 +47,7 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") protected val shape:
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Float> = DefaultFloatNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Float> = DefaultFloatNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultFloatNDArrayFactory: NumericalNDArrayFactory<Float> {
-    override fun alloc(lengths: IntArray) = DefaultFloatNDArray(lengths)
+    override fun alloc(lengths: IntArray) = DefaultFloatNDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.0f }
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultFloatNDArrayFactory: NumericalNDArrayFactory<Float> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> Float): NDArray<Float> {
-        return DefaultFloatNDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = DefaultFloatNDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<Float> {
-        return DefaultFloatNDArray(*lengths).fill {
-            0.toFloat()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.0f }
 
-    override fun ones(vararg lengths: Int): NDArray<Float> {
-        return DefaultFloatNDArray(*lengths).fill {
-            1.toFloat()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.0f }
 
-    override fun rand(vararg lengths: Int): NDArray<Float> {
-        return DefaultFloatNDArray(*lengths).fill {
-            0.toFloat()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.0f }
 
-    override fun randn(vararg lengths: Int): NDArray<Float> {
-        return DefaultFloatNDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().toFloat()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toFloat()
     }
-
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArrayFactory.kt
@@ -15,9 +15,11 @@ class DefaultFloatNDArrayFactory: NumericalNDArrayFactory<Float> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.0f }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.0f }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toFloat()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().toFloat()
+        koma.internal.getRng().nextGaussian().toFloat()
     }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
@@ -42,6 +42,7 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<T> = DefaultGenericNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
@@ -34,8 +34,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): T = storage[index]
-    override fun setLinear(index: Int, value: T) { storage[index] = value }
+    override fun getGeneric(i: Int): T = storage[i]
+    override fun setGeneric(i: Int, value: T) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: T) {
         checkIndices(indices)
@@ -48,66 +48,72 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        val ele = getGeneric(*indices)
+    override fun getDouble(i: Int): Double {
+        val ele = getGeneric(i)
         if (ele is Double)
             return ele
         else
             error(wrongType)
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        setGeneric(indices=*indices, value=value as T)
+    override fun setDouble(i: Int, value: Double) {
+       setGeneric(i, value as T)
     }
-    override fun getByte(vararg indices: Int): Byte {
-        val ele = getGeneric(*indices)
+
+    override fun getByte(i: Int): Byte {
+        val ele = getGeneric(i)
         if (ele is Byte)
             return ele
         else
             error(wrongType)
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        setGeneric(indices=*indices, value=value as T)
+    override fun setByte(i: Int, value: Byte) {
+       setGeneric(i, value as T)
     }
-    override fun getInt(vararg indices: Int): Int {
-        val ele = getGeneric(*indices)
+
+    override fun getInt(i: Int): Int {
+        val ele = getGeneric(i)
         if (ele is Int)
             return ele
         else
             error(wrongType)
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        setGeneric(indices=*indices, value=value as T)
+    override fun setInt(i: Int, value: Int) {
+       setGeneric(i, value as T)
     }
-    override fun getFloat(vararg indices: Int): Float {
-        val ele = getGeneric(*indices)
+
+    override fun getFloat(i: Int): Float {
+        val ele = getGeneric(i)
         if (ele is Float)
             return ele
         else
             error(wrongType)
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        setGeneric(indices=*indices, value=value as T)
+    override fun setFloat(i: Int, value: Float) {
+       setGeneric(i, value as T)
     }
-    override fun getLong(vararg indices: Int): Long {
-        val ele = getGeneric(*indices)
+
+    override fun getLong(i: Int): Long {
+        val ele = getGeneric(i)
         if (ele is Long)
             return ele
         else
             error(wrongType)
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        setGeneric(indices=*indices, value=value as T)
+    override fun setLong(i: Int, value: Long) {
+       setGeneric(i, value as T)
     }
-    override fun getShort(vararg indices: Int): Short {
-        val ele = getGeneric(*indices)
+
+    override fun getShort(i: Int): Short {
+        val ele = getGeneric(i)
         if (ele is Short)
             return ele
         else
             error(wrongType)
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        setGeneric(indices=*indices, value=value as T)
+    override fun setShort(i: Int, value: Short) {
+       setGeneric(i, value as T)
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultGenericNDArray<T>(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultGenericNDArray<T>(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->T)? = null): NDArray<T> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->T)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -44,7 +47,7 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<T> = DefaultGenericNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<T> = DefaultGenericNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,8 +58,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         else
             error(wrongType)
     }
-    override fun setDouble(i: Int, value: Double) {
-       setGeneric(i, value as T)
+    override fun setDouble(i: Int, v: Double) {
+       setGeneric(i, v as T)
     }
 
     override fun getByte(i: Int): Byte {
@@ -66,8 +69,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         else
             error(wrongType)
     }
-    override fun setByte(i: Int, value: Byte) {
-       setGeneric(i, value as T)
+    override fun setByte(i: Int, v: Byte) {
+       setGeneric(i, v as T)
     }
 
     override fun getInt(i: Int): Int {
@@ -77,8 +80,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         else
             error(wrongType)
     }
-    override fun setInt(i: Int, value: Int) {
-       setGeneric(i, value as T)
+    override fun setInt(i: Int, v: Int) {
+       setGeneric(i, v as T)
     }
 
     override fun getFloat(i: Int): Float {
@@ -88,8 +91,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         else
             error(wrongType)
     }
-    override fun setFloat(i: Int, value: Float) {
-       setGeneric(i, value as T)
+    override fun setFloat(i: Int, v: Float) {
+       setGeneric(i, v as T)
     }
 
     override fun getLong(i: Int): Long {
@@ -99,8 +102,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         else
             error(wrongType)
     }
-    override fun setLong(i: Int, value: Long) {
-       setGeneric(i, value as T)
+    override fun setLong(i: Int, v: Long) {
+       setGeneric(i, v as T)
     }
 
     override fun getShort(i: Int): Short {
@@ -110,8 +113,8 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
         else
             error(wrongType)
     }
-    override fun setShort(i: Int, value: Short) {
-       setGeneric(i, value as T)
+    override fun setShort(i: Int, v: Short) {
+       setGeneric(i, v as T)
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultGenericNDArray<T>(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultGenericNDArray<T>(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->T)? = null): NDArray<T> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->T)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +44,7 @@ storage = Array(shape.reduce{ a, b-> a * b}, {init?.invoke(linearToNIdx(it)) as 
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<T> = DefaultGenericNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<T> = DefaultGenericNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArrayFactory.kt
@@ -4,7 +4,5 @@ import koma.ndarray.GenericNDArrayFactory
 import koma.ndarray.NDArray
 
 class DefaultGenericNDArrayFactory<T>: GenericNDArrayFactory<T> {
-    override fun create(vararg lengths: Int, filler: (IntArray) -> T): NDArray<T> {
-        return DefaultGenericNDArray(shape=*lengths, init=filler)
-    }
+    override fun alloc(lengths: IntArray) = DefaultGenericNDArray<T>(lengths)
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArrayFactory.kt
@@ -4,5 +4,5 @@ import koma.ndarray.GenericNDArrayFactory
 import koma.ndarray.NDArray
 
 class DefaultGenericNDArrayFactory<T>: GenericNDArrayFactory<T> {
-    override fun alloc(lengths: IntArray) = DefaultGenericNDArray<T>(lengths)
+    override fun alloc(lengths: IntArray) = DefaultGenericNDArray<T>(shape = *lengths)
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
@@ -37,8 +37,8 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): Int = storage[index]
-    override fun setLinear(index: Int, value: Int) { storage[index] = value }
+    override fun getGeneric(i: Int): Int = storage[i]
+    override fun setGeneric(i: Int, value: Int) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: Int) {
         checkIndices(indices)
@@ -51,60 +51,54 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+    override fun getDouble(i: Int): Double {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toInt()
+    override fun setDouble(i: Int, value: Double) {
+        storage[checkLinearIndex(i)] = value.toInt()
     }
-    override fun getByte(vararg indices: Int): Byte {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getByte(i: Int): Byte {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toInt()
+    override fun setByte(i: Int, value: Byte) {
+        storage[checkLinearIndex(i)] = value.toInt()
     }
-    override fun getInt(vararg indices: Int): Int {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getInt(i: Int): Int {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toInt()
+    override fun setInt(i: Int, value: Int) {
+        storage[checkLinearIndex(i)] = value.toInt()
     }
-    override fun getFloat(vararg indices: Int): Float {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getFloat(i: Int): Float {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toInt()
+    override fun setFloat(i: Int, value: Float) {
+        storage[checkLinearIndex(i)] = value.toInt()
     }
-    override fun getLong(vararg indices: Int): Long {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getLong(i: Int): Long {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toInt()
+    override fun setLong(i: Int, value: Long) {
+        storage[checkLinearIndex(i)] = value.toInt()
     }
-    override fun getShort(vararg indices: Int): Short {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getShort(i: Int): Short {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toInt()
+    override fun setShort(i: Int, value: Short) {
+        storage[checkLinearIndex(i)] = value.toInt()
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
@@ -45,6 +45,7 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<Int> = DefaultIntNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultIntNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->Int)? = null): NDArray<Int> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Int)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -50,7 +47,7 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") protected val shape: I
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Int> = DefaultIntNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Int> = DefaultIntNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultIntNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->Int)? = null): NDArray<Int> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Int)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +50,7 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Int> = DefaultIntNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Int> = DefaultIntNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,48 +58,48 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
         val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(i: Int, value: Double) {
-        storage[checkLinearIndex(i)] = value.toInt()
+    override fun setDouble(i: Int, v: Double) {
+        storage[checkLinearIndex(i)] = v.toInt()
     }
 
     override fun getByte(i: Int): Byte {
         val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(i: Int, value: Byte) {
-        storage[checkLinearIndex(i)] = value.toInt()
+    override fun setByte(i: Int, v: Byte) {
+        storage[checkLinearIndex(i)] = v.toInt()
     }
 
     override fun getInt(i: Int): Int {
         val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(i: Int, value: Int) {
-        storage[checkLinearIndex(i)] = value.toInt()
+    override fun setInt(i: Int, v: Int) {
+        storage[checkLinearIndex(i)] = v.toInt()
     }
 
     override fun getFloat(i: Int): Float {
         val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(i: Int, value: Float) {
-        storage[checkLinearIndex(i)] = value.toInt()
+    override fun setFloat(i: Int, v: Float) {
+        storage[checkLinearIndex(i)] = v.toInt()
     }
 
     override fun getLong(i: Int): Long {
         val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(i: Int, value: Long) {
-        storage[checkLinearIndex(i)] = value.toInt()
+    override fun setLong(i: Int, v: Long) {
+        storage[checkLinearIndex(i)] = v.toInt()
     }
 
     override fun getShort(i: Int): Short {
         val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(i: Int, value: Short) {
-        storage[checkLinearIndex(i)] = value.toInt()
+    override fun setShort(i: Int, v: Short) {
+        storage[checkLinearIndex(i)] = v.toInt()
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultIntNDArrayFactory: NumericalNDArrayFactory<Int> {
-    override fun alloc(lengths: IntArray) = DefaultIntNDArray(lengths)
+    override fun alloc(lengths: IntArray) = DefaultIntNDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0 }
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultIntNDArrayFactory: NumericalNDArrayFactory<Int> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> Int): NDArray<Int> {
-        return DefaultIntNDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = DefaultIntNDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<Int> {
-        return DefaultIntNDArray(*lengths).fill {
-            0.toInt()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0 }
 
-    override fun ones(vararg lengths: Int): NDArray<Int> {
-        return DefaultIntNDArray(*lengths).fill {
-            1.toInt()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1 }
 
-    override fun rand(vararg lengths: Int): NDArray<Int> {
-        return DefaultIntNDArray(*lengths).fill {
-            0.toInt()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0 }
 
-    override fun randn(vararg lengths: Int): NDArray<Int> {
-        return DefaultIntNDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().toInt()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toInt()
     }
-
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArrayFactory.kt
@@ -15,9 +15,11 @@ class DefaultIntNDArrayFactory: NumericalNDArrayFactory<Int> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1 }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0 }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toInt()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().toInt()
+        koma.internal.getRng().nextGaussian().toInt()
     }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultLongNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->Long)? = null): NDArray<Long> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Long)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -50,7 +47,7 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") protected val shape: 
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Long> = DefaultLongNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Long> = DefaultLongNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultLongNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->Long)? = null): NDArray<Long> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Long)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +50,7 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Long> = DefaultLongNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Long> = DefaultLongNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,48 +58,48 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
         val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(i: Int, value: Double) {
-        storage[checkLinearIndex(i)] = value.toLong()
+    override fun setDouble(i: Int, v: Double) {
+        storage[checkLinearIndex(i)] = v.toLong()
     }
 
     override fun getByte(i: Int): Byte {
         val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(i: Int, value: Byte) {
-        storage[checkLinearIndex(i)] = value.toLong()
+    override fun setByte(i: Int, v: Byte) {
+        storage[checkLinearIndex(i)] = v.toLong()
     }
 
     override fun getInt(i: Int): Int {
         val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(i: Int, value: Int) {
-        storage[checkLinearIndex(i)] = value.toLong()
+    override fun setInt(i: Int, v: Int) {
+        storage[checkLinearIndex(i)] = v.toLong()
     }
 
     override fun getFloat(i: Int): Float {
         val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(i: Int, value: Float) {
-        storage[checkLinearIndex(i)] = value.toLong()
+    override fun setFloat(i: Int, v: Float) {
+        storage[checkLinearIndex(i)] = v.toLong()
     }
 
     override fun getLong(i: Int): Long {
         val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(i: Int, value: Long) {
-        storage[checkLinearIndex(i)] = value.toLong()
+    override fun setLong(i: Int, v: Long) {
+        storage[checkLinearIndex(i)] = v.toLong()
     }
 
     override fun getShort(i: Int): Short {
         val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(i: Int, value: Short) {
-        storage[checkLinearIndex(i)] = value.toLong()
+    override fun setShort(i: Int, v: Short) {
+        storage[checkLinearIndex(i)] = v.toLong()
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
@@ -37,8 +37,8 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): Long = storage[index]
-    override fun setLinear(index: Int, value: Long) { storage[index] = value }
+    override fun getGeneric(i: Int): Long = storage[i]
+    override fun setGeneric(i: Int, value: Long) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: Long) {
         checkIndices(indices)
@@ -51,60 +51,54 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+    override fun getDouble(i: Int): Double {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toLong()
+    override fun setDouble(i: Int, value: Double) {
+        storage[checkLinearIndex(i)] = value.toLong()
     }
-    override fun getByte(vararg indices: Int): Byte {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getByte(i: Int): Byte {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toLong()
+    override fun setByte(i: Int, value: Byte) {
+        storage[checkLinearIndex(i)] = value.toLong()
     }
-    override fun getInt(vararg indices: Int): Int {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getInt(i: Int): Int {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toLong()
+    override fun setInt(i: Int, value: Int) {
+        storage[checkLinearIndex(i)] = value.toLong()
     }
-    override fun getFloat(vararg indices: Int): Float {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getFloat(i: Int): Float {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toLong()
+    override fun setFloat(i: Int, value: Float) {
+        storage[checkLinearIndex(i)] = value.toLong()
     }
-    override fun getLong(vararg indices: Int): Long {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getLong(i: Int): Long {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toLong()
+    override fun setLong(i: Int, value: Long) {
+        storage[checkLinearIndex(i)] = value.toLong()
     }
-    override fun getShort(vararg indices: Int): Short {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getShort(i: Int): Short {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toLong()
+    override fun setShort(i: Int, value: Short) {
+        storage[checkLinearIndex(i)] = value.toLong()
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
@@ -45,6 +45,7 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<Long> = DefaultLongNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultLongNDArrayFactory: NumericalNDArrayFactory<Long> {
-    override fun alloc(lengths: IntArray) = DefaultLongNDArray(lengths)
+    override fun alloc(lengths: IntArray) = DefaultLongNDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0L }
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultLongNDArrayFactory: NumericalNDArrayFactory<Long> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> Long): NDArray<Long> {
-        return DefaultLongNDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = DefaultLongNDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<Long> {
-        return DefaultLongNDArray(*lengths).fill {
-            0.toLong()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0L }
 
-    override fun ones(vararg lengths: Int): NDArray<Long> {
-        return DefaultLongNDArray(*lengths).fill {
-            1.toLong()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1L }
 
-    override fun rand(vararg lengths: Int): NDArray<Long> {
-        return DefaultLongNDArray(*lengths).fill {
-            0.toLong()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0L }
 
-    override fun randn(vararg lengths: Int): NDArray<Long> {
-        return DefaultLongNDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().toLong()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toLong()
     }
-
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArrayFactory.kt
@@ -15,9 +15,11 @@ class DefaultLongNDArrayFactory: NumericalNDArrayFactory<Long> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1L }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0L }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toLong()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().toLong()
+        koma.internal.getRng().nextGaussian().toLong()
     }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
@@ -45,6 +45,7 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<Short> = DefaultShortNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
@@ -37,8 +37,8 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): Short = storage[index]
-    override fun setLinear(index: Int, value: Short) { storage[index] = value }
+    override fun getGeneric(i: Int): Short = storage[i]
+    override fun setGeneric(i: Int, value: Short) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: Short) {
         checkIndices(indices)
@@ -51,60 +51,54 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
-    override fun getDouble(vararg indices: Int): Double {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+    override fun getDouble(i: Int): Double {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(vararg indices: Int, value: Double) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toShort()
+    override fun setDouble(i: Int, value: Double) {
+        storage[checkLinearIndex(i)] = value.toShort()
     }
-    override fun getByte(vararg indices: Int): Byte {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getByte(i: Int): Byte {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(vararg indices: Int, value: Byte) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toShort()
+    override fun setByte(i: Int, value: Byte) {
+        storage[checkLinearIndex(i)] = value.toShort()
     }
-    override fun getInt(vararg indices: Int): Int {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getInt(i: Int): Int {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(vararg indices: Int, value: Int) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toShort()
+    override fun setInt(i: Int, value: Int) {
+        storage[checkLinearIndex(i)] = value.toShort()
     }
-    override fun getFloat(vararg indices: Int): Float {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getFloat(i: Int): Float {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(vararg indices: Int, value: Float) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toShort()
+    override fun setFloat(i: Int, value: Float) {
+        storage[checkLinearIndex(i)] = value.toShort()
     }
-    override fun getLong(vararg indices: Int): Long {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getLong(i: Int): Long {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(vararg indices: Int, value: Long) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toShort()
+    override fun setLong(i: Int, value: Long) {
+        storage[checkLinearIndex(i)] = value.toShort()
     }
-    override fun getShort(vararg indices: Int): Short {
-        checkIndices(indices)
-        val ele = storage[nIdxToLinear(indices)]
+
+    override fun getShort(i: Int): Short {
+        val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(vararg indices: Int, value: Short) {
-        checkIndices(indices)
-        storage[nIdxToLinear(indices)] = value.toShort()
+    override fun setShort(i: Int, value: Short) {
+        storage[checkLinearIndex(i)] = value.toShort()
     }
+
 
 
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class DefaultShortNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->Short)? = null): NDArray<Short> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Short)? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +50,7 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Short> = DefaultShortNDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Short> = DefaultShortNDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"
@@ -55,48 +58,48 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
         val ele = storage[checkLinearIndex(i)]
         return ele.toDouble()
     }
-    override fun setDouble(i: Int, value: Double) {
-        storage[checkLinearIndex(i)] = value.toShort()
+    override fun setDouble(i: Int, v: Double) {
+        storage[checkLinearIndex(i)] = v.toShort()
     }
 
     override fun getByte(i: Int): Byte {
         val ele = storage[checkLinearIndex(i)]
         return ele.toByte()
     }
-    override fun setByte(i: Int, value: Byte) {
-        storage[checkLinearIndex(i)] = value.toShort()
+    override fun setByte(i: Int, v: Byte) {
+        storage[checkLinearIndex(i)] = v.toShort()
     }
 
     override fun getInt(i: Int): Int {
         val ele = storage[checkLinearIndex(i)]
         return ele.toInt()
     }
-    override fun setInt(i: Int, value: Int) {
-        storage[checkLinearIndex(i)] = value.toShort()
+    override fun setInt(i: Int, v: Int) {
+        storage[checkLinearIndex(i)] = v.toShort()
     }
 
     override fun getFloat(i: Int): Float {
         val ele = storage[checkLinearIndex(i)]
         return ele.toFloat()
     }
-    override fun setFloat(i: Int, value: Float) {
-        storage[checkLinearIndex(i)] = value.toShort()
+    override fun setFloat(i: Int, v: Float) {
+        storage[checkLinearIndex(i)] = v.toShort()
     }
 
     override fun getLong(i: Int): Long {
         val ele = storage[checkLinearIndex(i)]
         return ele.toLong()
     }
-    override fun setLong(i: Int, value: Long) {
-        storage[checkLinearIndex(i)] = value.toShort()
+    override fun setLong(i: Int, v: Long) {
+        storage[checkLinearIndex(i)] = v.toShort()
     }
 
     override fun getShort(i: Int): Short {
         val ele = storage[checkLinearIndex(i)]
         return ele.toShort()
     }
-    override fun setShort(i: Int, value: Short) {
-        storage[checkLinearIndex(i)] = value.toShort()
+    override fun setShort(i: Int, v: Short) {
+        storage[checkLinearIndex(i)] = v.toShort()
     }
 
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class DefaultShortNDArray(@KomaJsName("shape_private") protected val shape: IntArray,
+open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->Short)? = null): NDArray<Short> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->Short)? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -50,7 +47,7 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") protected val shape:
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<Short> = DefaultShortNDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<Short> = DefaultShortNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultShortNDArrayFactory: NumericalNDArrayFactory<Short> {
-    override fun alloc(lengths: IntArray) = DefaultShortNDArray(lengths)
+    override fun alloc(lengths: IntArray) = DefaultShortNDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.toShort() }
 

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class DefaultShortNDArrayFactory: NumericalNDArrayFactory<Short> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> Short): NDArray<Short> {
-        return DefaultShortNDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = DefaultShortNDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<Short> {
-        return DefaultShortNDArray(*lengths).fill {
-            0.toShort()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0.toShort() }
 
-    override fun ones(vararg lengths: Int): NDArray<Short> {
-        return DefaultShortNDArray(*lengths).fill {
-            1.toShort()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.toShort() }
 
-    override fun rand(vararg lengths: Int): NDArray<Short> {
-        return DefaultShortNDArray(*lengths).fill {
-            0.toShort()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.toShort() }
 
-    override fun randn(vararg lengths: Int): NDArray<Short> {
-        return DefaultShortNDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().toShort()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toShort()
     }
-
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArrayFactory.kt
@@ -15,9 +15,11 @@ class DefaultShortNDArrayFactory: NumericalNDArrayFactory<Short> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1.toShort() }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0.toShort() }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().toShort()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().toShort()
+        koma.internal.getRng().nextGaussian().toShort()
     }
 }

--- a/koma-core-api/common/src/koma/internal/default/utils/indexing.kt
+++ b/koma-core-api/common/src/koma/internal/default/utils/indexing.kt
@@ -39,7 +39,7 @@ fun <T> NDArray<T>.widthOfDims() = shape()
             removeAt(0)
         }
 
-fun <T> NDArray<T>.checkIndices(indices: IntArray) {
+fun <T> NDArray<T>.checkIndices(indices: IntArray) = indices.also {
     val shape = shape()
     if (indices.size != shape.size)
         throw IllegalArgumentException("Cannot index an array with shape ${shape.toList()} with " +
@@ -51,6 +51,23 @@ fun <T> NDArray<T>.checkIndices(indices: IntArray) {
     }
 }
 
+fun <T> NDArray<T>.safeIdxToLinear(indices: IntArray) = nIdxToLinear(checkIndices(indices))
+
+fun <T> NDArray<T>.checkLinearIndex(index: Int) = index.also {
+    if (index < 0)
+        throw IllegalArgumentException("Negative indices are not supported")
+    else size.let { n ->
+        if (index >= n) {
+            val an = when("$n"[0]) {
+                '1','8' -> "an"
+                else    -> "a"
+            }
+            throw IllegalArgumentException("Cannot index $an $n-element array with shape " +
+                                           "${shape().toList()} at linear position $index " +
+                                           "(out of bounds)")
+        }
+    }
+}
 
 /**
  * Similar to reduceRight, except the results of each stage are stored off into

--- a/koma-core-api/common/src/koma/internal/default/utils/indexing.kt
+++ b/koma-core-api/common/src/koma/internal/default/utils/indexing.kt
@@ -51,7 +51,7 @@ fun <T> NDArray<T>.checkIndices(indices: IntArray) = indices.also {
     }
 }
 
-fun <T> NDArray<T>.safeIdxToLinear(indices: IntArray) = nIdxToLinear(checkIndices(indices))
+fun <T> NDArray<T>.safeNIdxToLinear(indices: IntArray) = nIdxToLinear(checkIndices(indices))
 
 fun <T> NDArray<T>.checkLinearIndex(index: Int) = index.also {
     if (index < 0)

--- a/koma-core-api/common/src/koma/matrix/Matrix.kt
+++ b/koma-core-api/common/src/koma/matrix/Matrix.kt
@@ -119,18 +119,6 @@ interface Matrix<T>: NDArray<T> {
     fun getDouble(i: Int, j: Int): Double
     @KomaJsName("getFloat")
     fun getFloat(i: Int, j: Int): Float
-    @KomaJsName("getInt1D")
-    fun getInt(i: Int): Int
-    @KomaJsName("getDouble1D")
-    fun getDouble(i: Int): Double
-    @KomaJsName("getFloat1D")
-    fun getFloat(i: Int): Float
-    @KomaJsName("setInt1D")
-    fun setInt(i: Int, v: Int)
-    @KomaJsName("setDouble1D")
-    fun setDouble(i: Int, v: Double)
-    @KomaJsName("setFloat1D")
-    fun setFloat(i: Int, v: Float)
     @KomaJsName("setInt")
     fun setInt(i: Int, j: Int, v: Int)
     @KomaJsName("setDouble")
@@ -139,12 +127,25 @@ interface Matrix<T>: NDArray<T> {
     fun setFloat(i: Int, j: Int, v: Float)
     @KomaJsName("getGeneric")
     fun getGeneric(i: Int, j: Int): T
-    @KomaJsName("getGeneric1D")
-    fun getGeneric(i: Int): T
     @KomaJsName("setGeneric")
     fun setGeneric(i: Int, j: Int, v: T)
-    @KomaJsName("setGeneric1D")
-    fun setGeneric(i: Int, v: T)
+
+    //!{{ 1D overrides
+
+    // GENERATED CODE! See build.gradle
+
+    override fun getLong(i: Int): Long = getGeneric(i) as Long
+    override fun setLong(i: Int, value: Long) { setGeneric(i, value as T) }
+
+
+    override fun getShort(i: Int): Short = getGeneric(i) as Short
+    override fun setShort(i: Int, value: Short) { setGeneric(i, value as T) }
+
+
+    override fun getByte(i: Int): Byte = getGeneric(i) as Byte
+    override fun setByte(i: Int, value: Byte) { setGeneric(i, value as T) }
+
+    //!}}
 
     /**
      * Retrieves the data formatted as doubles in row-major order

--- a/koma-core-api/common/src/koma/matrix/Matrix.kt
+++ b/koma-core-api/common/src/koma/matrix/Matrix.kt
@@ -140,23 +140,6 @@ interface Matrix<T>: NDArray<T> {
     @KomaJsName("setGeneric")
     fun setGeneric(i: Int, j: Int, v: T)
 
-    //!{{ 1D overrides
-
-    // GENERATED CODE! See build.gradle
-
-    override fun getLong(i: Int): Long = getGeneric(i) as Long
-    override fun setLong(i: Int, v: Long) { setGeneric(i, v as T) }
-
-
-    override fun getShort(i: Int): Short = getGeneric(i) as Short
-    override fun setShort(i: Int, v: Short) { setGeneric(i, v as T) }
-
-
-    override fun getByte(i: Int): Byte = getGeneric(i) as Byte
-    override fun setByte(i: Int, v: Byte) { setGeneric(i, v as T) }
-
-    //!}}
-
     /**
      * Retrieves the data formatted as doubles in row-major order
      * This method is only for performance over potentially boxing get(Double)

--- a/koma-core-api/common/src/koma/matrix/Matrix.kt
+++ b/koma-core-api/common/src/koma/matrix/Matrix.kt
@@ -135,15 +135,15 @@ interface Matrix<T>: NDArray<T> {
     // GENERATED CODE! See build.gradle
 
     override fun getLong(i: Int): Long = getGeneric(i) as Long
-    override fun setLong(i: Int, value: Long) { setGeneric(i, value as T) }
+    override fun setLong(i: Int, v: Long) { setGeneric(i, v as T) }
 
 
     override fun getShort(i: Int): Short = getGeneric(i) as Short
-    override fun setShort(i: Int, value: Short) { setGeneric(i, value as T) }
+    override fun setShort(i: Int, v: Short) { setGeneric(i, v as T) }
 
 
     override fun getByte(i: Int): Byte = getGeneric(i) as Byte
-    override fun setByte(i: Int, value: Byte) { setGeneric(i, value as T) }
+    override fun setByte(i: Int, v: Byte) { setGeneric(i, v as T) }
 
     //!}}
 

--- a/koma-core-api/common/src/koma/matrix/Matrix.kt
+++ b/koma-core-api/common/src/koma/matrix/Matrix.kt
@@ -337,6 +337,7 @@ interface Matrix<T>: NDArray<T> {
 
     override fun getLinear(index: Int): T = getGeneric(index)
     override fun setLinear(index: Int, value: T) = setGeneric(index, value)
+    override val size get() = this.numRows() * this.numCols()
     override fun shape(): List<Int> = listOf(this.numRows(), this.numCols())
     override fun getBaseArray(): Any = this.getBaseMatrix()
 

--- a/koma-core-api/common/src/koma/matrix/Matrix.kt
+++ b/koma-core-api/common/src/koma/matrix/Matrix.kt
@@ -65,6 +65,16 @@ interface Matrix<T>: NDArray<T> {
             set(value) { _intFactory = value}
         private var _intFactory: MatrixFactory<Matrix<Int>>? = null
 
+        @Suppress("UNCHECKED_CAST")
+        inline operator fun <reified T> invoke(rows: Int, cols: Int,
+                                               crossinline filler: (Int, Int) -> T): Matrix<T> =
+                when(T::class) {
+                    Double::class -> doubleFactory.zeros(rows, cols).fill { r, c -> filler(r, c) as Double } as Matrix<T>
+                    Float::class  -> floatFactory.zeros(rows, cols).fill { r, c -> filler(r, c) as Float } as Matrix<T>
+                    Int::class    -> intFactory.zeros(rows, cols).fill { r, c -> filler(r, c) as Int } as Matrix<T>
+                    else          -> error("Unsupported Matrix type ${T::class.simpleName}")
+                }
+
     }
     // Algebraic Operators
     @KomaJsName("divInt")

--- a/koma-core-api/common/src/koma/ndarray/GenericNDArrayFactory.kt
+++ b/koma-core-api/common/src/koma/ndarray/GenericNDArrayFactory.kt
@@ -5,5 +5,12 @@ package koma.ndarray
  * Generic parameter is the type of the element.
  */
 interface GenericNDArrayFactory<T> {
-    fun create(vararg lengths: Int, filler: (IntArray)->T): NDArray<T>
+    /**
+     * Generate an ND container of the requested shape without initializing
+     * its contents.
+     *
+     * Depending on backend and platform, the resulting array may be,
+     * equivalent to zeros(*lengths), or may be initialized to memory garbage.
+     */
+    fun alloc(lengths: IntArray): NDArray<T>
 }

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -58,6 +58,7 @@ interface NDArray<T> {
     fun getLinear(index: Int): T
     fun setLinear(index: Int, value: T)
 
+    val size: Int get() = shape().reduce { a, b -> a * b }
     fun shape(): List<Int>
     fun copy(): NDArray<T>
 
@@ -67,7 +68,7 @@ interface NDArray<T> {
         return object: Iterable<T> {
             override fun iterator(): Iterator<T> = object: Iterator<T> {
                 private var cursor = 0
-                private val size = this@NDArray.shape().reduce{a,b->a*b}
+                private val size = this@NDArray.size
                 override fun next(): T {
                     cursor += 1
                     // TODO: Either make 1D access work like Matrix or fix this

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -29,32 +29,32 @@ interface NDArray<T> {
 
         var doubleFactory: NumericalNDArrayFactory<Double>
             get() = _doubleFactory ?: getDoubleNDArrayFactory().also { _doubleFactory = it }
-            set(value) { _doubleFactory = value}
+            set(value) { _doubleFactory = value }
         private var _doubleFactory: NumericalNDArrayFactory<Double>? = null
 
         var floatFactory: NumericalNDArrayFactory<Float>
             get() = _floatFactory ?: getFloatNDArrayFactory().also { _floatFactory = it }
-            set(value) { _floatFactory = value}
+            set(value) { _floatFactory = value }
         private var _floatFactory: NumericalNDArrayFactory<Float>? = null
 
         var longFactory: NumericalNDArrayFactory<Long>
             get() = _longFactory ?: getLongNDArrayFactory().also { _longFactory = it }
-            set(value) { _longFactory = value}
+            set(value) { _longFactory = value }
         private var _longFactory: NumericalNDArrayFactory<Long>? = null
 
         var intFactory: NumericalNDArrayFactory<Int>
             get() = _intFactory ?: getIntNDArrayFactory().also { _intFactory = it }
-            set(value) { _intFactory = value}
+            set(value) { _intFactory = value }
         private var _intFactory: NumericalNDArrayFactory<Int>? = null
 
         var shortFactory: NumericalNDArrayFactory<Short>
             get() = _shortFactory ?: getShortNDArrayFactory().also { _shortFactory = it }
-            set(value) { _shortFactory = value}
+            set(value) { _shortFactory = value }
         private var _shortFactory: NumericalNDArrayFactory<Short>? = null
 
         var byteFactory: NumericalNDArrayFactory<Byte>
             get() = _byteFactory ?: getByteNDArrayFactory().also { _byteFactory = it }
-            set(value) { _byteFactory = value}
+            set(value) { _byteFactory = value }
         private var _byteFactory: NumericalNDArrayFactory<Byte>? = null
 
         fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
@@ -117,11 +117,6 @@ interface NDArray<T> {
     @KomaJsName("setGeneric1D")
     fun setGeneric(i: Int, v: T)
 
-
-    //!{{ primitive get/set
-
-    // GENERATED CODE! See build.gradle
-
     @KomaJsName("getDoubleND")
     fun getDouble(vararg indices: Int) = getDouble(safeIdxToLinear(indices))
     @KomaJsName("getDouble1D")
@@ -180,6 +175,4 @@ interface NDArray<T> {
     fun setByte(vararg indices: Int, v: Byte) = setByte(safeIdxToLinear(indices), v)
     @KomaJsName("setByte1D")
     fun setByte(i: Int, v: Byte) { setGeneric(i, v as T) }
-
-    //!}}
 }

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -4,7 +4,7 @@ import koma.extensions.create
 import koma.extensions.fill
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
-import koma.internal.default.utils.safeIdxToLinear
+import koma.internal.default.utils.safeNIdxToLinear
 import koma.matrix.*
 import kotlin.reflect.KClass
 import koma.util.IndexIterator
@@ -109,70 +109,70 @@ interface NDArray<T> {
     // to be used directly, but instead are used by ext funcs in `koma.extensions`.
 
     @KomaJsName("getGenericND")
-    fun getGeneric(vararg indices: Int) = getGeneric(safeIdxToLinear(indices))
+    fun getGeneric(vararg indices: Int) = getGeneric(safeNIdxToLinear(indices))
     @KomaJsName("getGeneric1D")
     fun getGeneric(i: Int): T
     @KomaJsName("setGenericND")
-    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeIdxToLinear(indices), v)
+    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeNIdxToLinear(indices), v)
     @KomaJsName("setGeneric1D")
     fun setGeneric(i: Int, v: T)
 
     @KomaJsName("getDoubleND")
-    fun getDouble(vararg indices: Int) = getDouble(safeIdxToLinear(indices))
+    fun getDouble(vararg indices: Int) = getDouble(safeNIdxToLinear(indices))
     @KomaJsName("getDouble1D")
     fun getDouble(i: Int): Double = (getGeneric(i) as Number).toDouble()
     @KomaJsName("setDoubleND")
-    fun setDouble(vararg indices: Int, v: Double) = setDouble(safeIdxToLinear(indices), v)
+    fun setDouble(vararg indices: Int, v: Double) = setDouble(safeNIdxToLinear(indices), v)
     @KomaJsName("setDouble1D")
     fun setDouble(i: Int, v: Double) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getFloatND")
-    fun getFloat(vararg indices: Int) = getFloat(safeIdxToLinear(indices))
+    fun getFloat(vararg indices: Int) = getFloat(safeNIdxToLinear(indices))
     @KomaJsName("getFloat1D")
     fun getFloat(i: Int): Float = (getGeneric(i) as Number).toFloat()
     @KomaJsName("setFloatND")
-    fun setFloat(vararg indices: Int, v: Float) = setFloat(safeIdxToLinear(indices), v)
+    fun setFloat(vararg indices: Int, v: Float) = setFloat(safeNIdxToLinear(indices), v)
     @KomaJsName("setFloat1D")
     fun setFloat(i: Int, v: Float) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getLongND")
-    fun getLong(vararg indices: Int) = getLong(safeIdxToLinear(indices))
+    fun getLong(vararg indices: Int) = getLong(safeNIdxToLinear(indices))
     @KomaJsName("getLong1D")
     fun getLong(i: Int): Long = (getGeneric(i) as Number).toLong()
     @KomaJsName("setLongND")
-    fun setLong(vararg indices: Int, v: Long) = setLong(safeIdxToLinear(indices), v)
+    fun setLong(vararg indices: Int, v: Long) = setLong(safeNIdxToLinear(indices), v)
     @KomaJsName("setLong1D")
     fun setLong(i: Int, v: Long) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getIntND")
-    fun getInt(vararg indices: Int) = getInt(safeIdxToLinear(indices))
+    fun getInt(vararg indices: Int) = getInt(safeNIdxToLinear(indices))
     @KomaJsName("getInt1D")
     fun getInt(i: Int): Int = (getGeneric(i) as Number).toInt()
     @KomaJsName("setIntND")
-    fun setInt(vararg indices: Int, v: Int) = setInt(safeIdxToLinear(indices), v)
+    fun setInt(vararg indices: Int, v: Int) = setInt(safeNIdxToLinear(indices), v)
     @KomaJsName("setInt1D")
     fun setInt(i: Int, v: Int) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getShortND")
-    fun getShort(vararg indices: Int) = getShort(safeIdxToLinear(indices))
+    fun getShort(vararg indices: Int) = getShort(safeNIdxToLinear(indices))
     @KomaJsName("getShort1D")
     fun getShort(i: Int): Short = (getGeneric(i) as Number).toShort()
     @KomaJsName("setShortND")
-    fun setShort(vararg indices: Int, v: Short) = setShort(safeIdxToLinear(indices), v)
+    fun setShort(vararg indices: Int, v: Short) = setShort(safeNIdxToLinear(indices), v)
     @KomaJsName("setShort1D")
     fun setShort(i: Int, v: Short) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getByteND")
-    fun getByte(vararg indices: Int) = getByte(safeIdxToLinear(indices))
+    fun getByte(vararg indices: Int) = getByte(safeNIdxToLinear(indices))
     @KomaJsName("getByte1D")
     fun getByte(i: Int): Byte = (getGeneric(i) as Number).toByte()
     @KomaJsName("setByteND")
-    fun setByte(vararg indices: Int, v: Byte) = setByte(safeIdxToLinear(indices), v)
+    fun setByte(vararg indices: Int, v: Byte) = setByte(safeNIdxToLinear(indices), v)
     @KomaJsName("setByte1D")
     fun setByte(i: Int, v: Byte) { setGeneric(i, v as T) }
 }

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -57,6 +57,9 @@ interface NDArray<T> {
             set(value) { _byteFactory = value }
         private var _byteFactory: NumericalNDArrayFactory<Byte>? = null
 
+        fun <T> allocGeneric(dims: IntArray) =
+            DefaultGenericNDArrayFactory<T>().alloc(dims)
+
         fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
             DefaultGenericNDArrayFactory<T>().create(*dims, filler = filler)
 

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -125,61 +125,61 @@ interface NDArray<T> {
     @KomaJsName("getDoubleND")
     fun getDouble(vararg indices: Int) = getDouble(safeIdxToLinear(indices))
     @KomaJsName("getDouble1D")
-    fun getDouble(i: Int): Double
+    fun getDouble(i: Int): Double = (getGeneric(i) as Number).toDouble()
     @KomaJsName("setDoubleND")
     fun setDouble(vararg indices: Int, v: Double) = setDouble(safeIdxToLinear(indices), v)
     @KomaJsName("setDouble1D")
-    fun setDouble(i: Int, v: Double)
+    fun setDouble(i: Int, v: Double) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getFloatND")
     fun getFloat(vararg indices: Int) = getFloat(safeIdxToLinear(indices))
     @KomaJsName("getFloat1D")
-    fun getFloat(i: Int): Float
+    fun getFloat(i: Int): Float = (getGeneric(i) as Number).toFloat()
     @KomaJsName("setFloatND")
     fun setFloat(vararg indices: Int, v: Float) = setFloat(safeIdxToLinear(indices), v)
     @KomaJsName("setFloat1D")
-    fun setFloat(i: Int, v: Float)
+    fun setFloat(i: Int, v: Float) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getLongND")
     fun getLong(vararg indices: Int) = getLong(safeIdxToLinear(indices))
     @KomaJsName("getLong1D")
-    fun getLong(i: Int): Long
+    fun getLong(i: Int): Long = (getGeneric(i) as Number).toLong()
     @KomaJsName("setLongND")
     fun setLong(vararg indices: Int, v: Long) = setLong(safeIdxToLinear(indices), v)
     @KomaJsName("setLong1D")
-    fun setLong(i: Int, v: Long)
+    fun setLong(i: Int, v: Long) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getIntND")
     fun getInt(vararg indices: Int) = getInt(safeIdxToLinear(indices))
     @KomaJsName("getInt1D")
-    fun getInt(i: Int): Int
+    fun getInt(i: Int): Int = (getGeneric(i) as Number).toInt()
     @KomaJsName("setIntND")
     fun setInt(vararg indices: Int, v: Int) = setInt(safeIdxToLinear(indices), v)
     @KomaJsName("setInt1D")
-    fun setInt(i: Int, v: Int)
+    fun setInt(i: Int, v: Int) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getShortND")
     fun getShort(vararg indices: Int) = getShort(safeIdxToLinear(indices))
     @KomaJsName("getShort1D")
-    fun getShort(i: Int): Short
+    fun getShort(i: Int): Short = (getGeneric(i) as Number).toShort()
     @KomaJsName("setShortND")
     fun setShort(vararg indices: Int, v: Short) = setShort(safeIdxToLinear(indices), v)
     @KomaJsName("setShort1D")
-    fun setShort(i: Int, v: Short)
+    fun setShort(i: Int, v: Short) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getByteND")
     fun getByte(vararg indices: Int) = getByte(safeIdxToLinear(indices))
     @KomaJsName("getByte1D")
-    fun getByte(i: Int): Byte
+    fun getByte(i: Int): Byte = (getGeneric(i) as Number).toByte()
     @KomaJsName("setByteND")
     fun setByte(vararg indices: Int, v: Byte) = setByte(safeIdxToLinear(indices), v)
     @KomaJsName("setByte1D")
-    fun setByte(i: Int, v: Byte)
+    fun setByte(i: Int, v: Byte) { setGeneric(i, v as T) }
 
     //!}}
 }

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -2,6 +2,7 @@ package koma.ndarray
 
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
+import koma.internal.default.utils.safeIdxToLinear
 import koma.matrix.*
 
 // TODO: broadcasting, iteration by selected dims, views, reshape
@@ -55,8 +56,11 @@ interface NDArray<T> {
         fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
             DefaultGenericNDArrayFactory<T>().create(*dims, filler = filler)
     }
-    fun getLinear(index: Int): T
-    fun setLinear(index: Int, value: T)
+
+    @Deprecated("Use NDArray.getGeneric", ReplaceWith("getGeneric"))
+    fun getLinear(index: Int): T = getGeneric(index)
+    @Deprecated("Use NDArray.getGeneric", ReplaceWith("setGeneric"))
+    fun setLinear(index: Int, value: T) = setGeneric(index, value = value)
 
     val size: Int get() = shape().reduce { a, b -> a * b }
     fun shape(): List<Int>
@@ -83,19 +87,78 @@ interface NDArray<T> {
     // Primitive optimized getter/setters to avoid boxing. Not intended
     // to be used directly, but instead are used by ext funcs in `koma.extensions`.
 
-    fun getGeneric(vararg indices: Int): T
-    fun getByte(vararg indices: Int): Byte
-    fun getDouble(vararg indices: Int): Double
-    fun getFloat(vararg indices: Int): Float
-    fun getInt(vararg indices: Int): Int
-    fun getLong(vararg indices: Int): Long
-    fun getShort(vararg indices: Int): Short
+    @KomaJsName("getGenericND")
+    fun getGeneric(vararg indices: Int) = getLinear(safeIdxToLinear(indices))
+    @KomaJsName("getGeneric1D")
+    fun getGeneric(i: Int): T
+    @KomaJsName("setGenericND")
+    fun setGeneric(vararg indices: Int, value: T) = setLinear(safeIdxToLinear(indices), value)
+    @KomaJsName("setGeneric1D")
+    fun setGeneric(i: Int, value: T)
 
-    fun setGeneric(vararg indices: Int, value: T)
-    fun setByte(vararg indices: Int, value: Byte)
-    fun setDouble(vararg indices: Int, value: Double)
-    fun setFloat(vararg indices: Int, value: Float)
-    fun setInt(vararg indices: Int, value: Int)
-    fun setLong(vararg indices: Int, value: Long)
-    fun setShort(vararg indices: Int, value: Short)
+
+    //!{{ primitive get/set
+
+    // GENERATED CODE! See build.gradle
+
+    @KomaJsName("getDoubleND")
+    fun getDouble(vararg indices: Int) = getDouble(safeIdxToLinear(indices))
+    @KomaJsName("getDouble1D")
+    fun getDouble(i: Int): Double
+    @KomaJsName("setDoubleND")
+    fun setDouble(vararg indices: Int, value: Double) = setDouble(safeIdxToLinear(indices), value)
+    @KomaJsName("setDouble1D")
+    fun setDouble(i: Int, v: Double)
+
+
+    @KomaJsName("getFloatND")
+    fun getFloat(vararg indices: Int) = getFloat(safeIdxToLinear(indices))
+    @KomaJsName("getFloat1D")
+    fun getFloat(i: Int): Float
+    @KomaJsName("setFloatND")
+    fun setFloat(vararg indices: Int, value: Float) = setFloat(safeIdxToLinear(indices), value)
+    @KomaJsName("setFloat1D")
+    fun setFloat(i: Int, v: Float)
+
+
+    @KomaJsName("getLongND")
+    fun getLong(vararg indices: Int) = getLong(safeIdxToLinear(indices))
+    @KomaJsName("getLong1D")
+    fun getLong(i: Int): Long
+    @KomaJsName("setLongND")
+    fun setLong(vararg indices: Int, value: Long) = setLong(safeIdxToLinear(indices), value)
+    @KomaJsName("setLong1D")
+    fun setLong(i: Int, v: Long)
+
+
+    @KomaJsName("getIntND")
+    fun getInt(vararg indices: Int) = getInt(safeIdxToLinear(indices))
+    @KomaJsName("getInt1D")
+    fun getInt(i: Int): Int
+    @KomaJsName("setIntND")
+    fun setInt(vararg indices: Int, value: Int) = setInt(safeIdxToLinear(indices), value)
+    @KomaJsName("setInt1D")
+    fun setInt(i: Int, v: Int)
+
+
+    @KomaJsName("getShortND")
+    fun getShort(vararg indices: Int) = getShort(safeIdxToLinear(indices))
+    @KomaJsName("getShort1D")
+    fun getShort(i: Int): Short
+    @KomaJsName("setShortND")
+    fun setShort(vararg indices: Int, value: Short) = setShort(safeIdxToLinear(indices), value)
+    @KomaJsName("setShort1D")
+    fun setShort(i: Int, v: Short)
+
+
+    @KomaJsName("getByteND")
+    fun getByte(vararg indices: Int) = getByte(safeIdxToLinear(indices))
+    @KomaJsName("getByte1D")
+    fun getByte(i: Int): Byte
+    @KomaJsName("setByteND")
+    fun setByte(vararg indices: Int, value: Byte) = setByte(safeIdxToLinear(indices), value)
+    @KomaJsName("setByte1D")
+    fun setByte(i: Int, v: Byte)
+
+    //!}}
 }

--- a/koma-core-api/common/src/koma/util/IndexIterator.kt
+++ b/koma-core-api/common/src/koma/util/IndexIterator.kt
@@ -1,0 +1,36 @@
+package koma.util
+
+/**
+ * An Iterator that counts indices of a given shape in row-major order, simultaneously in
+ * both array and linear form. Useful for stepping through N-dimensional data.
+ */
+data class IndexIterator(var nd: IntArray, var linear: Int = 0): Iterator<IndexIterator> {
+    private var needsAdvance = false
+    private val shape = nd
+    private val lastIndex = nd.size - 1
+    override fun hasNext(): Boolean {
+        if (needsAdvance) {
+            ++linear
+            for (idx in lastIndex downTo 0)
+                if (++nd[idx] >= shape[idx] && idx > 0)
+                    nd[idx] = 0
+                else
+                    break
+            needsAdvance = false
+        }
+        return nd.size > 0 && nd[0] < shape[0]
+    }
+    override fun next() = apply {
+        if (!hasNext())
+            throw NoSuchElementException("Iterator exhausted")
+        needsAdvance = true
+    }
+    init { nd = IntArray(nd.size) { 0 } }
+
+    companion object {
+        operator fun invoke(shapeFactory: ()->IntArray): Iterable<IndexIterator> = 
+            object : Iterable<IndexIterator> {
+                override fun iterator() = IndexIterator(shapeFactory())
+            }
+    }
+}

--- a/koma-tests/test/koma/CreatorsTests.kt
+++ b/koma-tests/test/koma/CreatorsTests.kt
@@ -1,6 +1,9 @@
 package koma
 
 import koma.extensions.*
+import koma.matrix.Matrix
+import koma.matrix.ejml.EJMLMatrix
+import koma.matrix.ejml.EJMLMatrixFactory
 import koma.util.test.*
 import org.junit.Assert
 import org.junit.Test
@@ -164,5 +167,14 @@ class CreatorsTests {
             assertFalse { allclose(a,e) }
             assertFalse { allclose(b,f) }
         }
+    }
+    @Test
+    fun testMagicConstructor() {
+        Matrix.doubleFactory = EJMLMatrixFactory()
+
+        assert(Matrix(4, 4) { row, col -> row+col.toDouble() } is EJMLMatrix)
+        assert(Matrix(4, 4) { row, col -> row+col.toDouble() }[2, 3] == 5.0)
+        assert(Matrix(4, 4) { row, col -> row+col }[1, 1] == 2)
+        assertFails { Matrix<String>(4, 4) { row, col -> "" } }
     }
 }

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -86,7 +86,14 @@ class NDTests {
         arr[0, 0] = square2
         assertFails { arr[1, 1] = square2 }
     }
-    
+
+    @Test
+    fun testSize() {
+        assert(DefaultNDArray<Any?>(2, 3) { 0 }.size == 6)
+        assert(DefaultNDArray<Any?>(2, 3, 4) { 0 }.size == 24)
+        assert(DefaultNDArray<Any?>(4, 0, 7) { 0 }.size == 0)
+    }
+
     @Test
     fun testShape() {
         assert(DefaultNDArray<Any?>(3, 3) { idx -> idx[0] }.shape() == listOf(3, 3))
@@ -159,7 +166,7 @@ class NDTests {
         a.forEachIndexedN { _, ele -> sum2 += ele }
         
         assert(sum == sum2)
-        assert(count == a.shape().reduce{ l,r -> l*r })
+        assert(count == a.size)
     }
     @Test
     fun testToMatrixOrNull() {

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -156,7 +156,7 @@ class NDTests {
         assert(a[3, 1, 3] == 3 * 2 + 1 * 3)
 
         a.forEachIndexedN { idx, ele -> assert(ele == idx[0] * 2 + idx[1] * 3) }
-        a.forEachIndexed { idx, ele -> assert(ele == a.getLinear(idx)) }
+        a.forEachIndexed { idx, ele -> assert(ele == a.getInt(idx)) }
 
         var sum = 0
         var count = 0
@@ -185,5 +185,11 @@ class NDTests {
                 "1.1"
         }
         assert(a.toMatrixOrNull() == null)
+    }
+    @Test
+    fun testMagicConstructor() {
+        assert(NDArray(1, 2, 3) { it.reduce { a, b -> a + b } } is DefaultIntNDArray)
+        assert(NDArray(1, 2, 3) { it.reduce { a, b -> a + b } }[0, 1, 2] == 3)
+        assert(NDArray(1, 2, 3) { "${it.toList()}" }[0, 1, 1] == listOf(0,1,1).toString())
     }
 }

--- a/templates/DefaultXNDArray.kt
+++ b/templates/DefaultXNDArray.kt
@@ -34,8 +34,8 @@ ${initStorage}
         checkIndices(indices)
         return storage[nIdxToLinear(indices)]
     }
-    override fun getLinear(index: Int): ${dtype} = storage[index]
-    override fun setLinear(index: Int, value: ${dtype}) { storage[index] = value }
+    override fun getGeneric(i: Int): ${dtype} = storage[i]
+    override fun setGeneric(i: Int, value: ${dtype}) { storage[i] = value }
 
     override fun setGeneric(vararg indices: Int, value: ${dtype}) {
         checkIndices(indices)

--- a/templates/DefaultXNDArray.kt
+++ b/templates/DefaultXNDArray.kt
@@ -42,6 +42,7 @@ ${initStorage}
         storage[nIdxToLinear(indices)] = value
     }
     // TODO: cache this
+    override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
     override fun copy(): NDArray<${dtype}> = Default${dtypeName}NDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage

--- a/templates/DefaultXNDArray.kt
+++ b/templates/DefaultXNDArray.kt
@@ -17,11 +17,8 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class Default${dtypeName}NDArray${genDec}(@KomaJsName("shape_private") protected val shape: IntArray,
+open class Default${dtypeName}NDArray${genDec}(@KomaJsName("shape_private") vararg protected val shape: Int,
                              init: ((IntArray)->${dtype})? = null): NDArray<${dtype}> {
-
-    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->${dtype})? = null)
-        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -47,7 +44,7 @@ ${initStorage}
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<${dtype}> = Default${dtypeName}NDArray(shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<${dtype}> = Default${dtypeName}NDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/templates/DefaultXNDArray.kt
+++ b/templates/DefaultXNDArray.kt
@@ -17,8 +17,11 @@ import koma.internal.default.utils.*
  * @param shape A vararg specifying the size of each dimension, e.g. a 3D array with size 4x6x8 would pass in 4,6,8)
  * @param init A function that takes a location in the new array and returns its initial value.
  */
-open class Default${dtypeName}NDArray${genDec}(@KomaJsName("shape_private") vararg protected val shape: Int,
+open class Default${dtypeName}NDArray${genDec}(@KomaJsName("shape_private") protected val shape: IntArray,
                              init: ((IntArray)->${dtype})? = null): NDArray<${dtype}> {
+
+    constructor(shape0: Int, vararg restOfShape: Int, init: ((IntArray)->${dtype})? = null)
+        : this(intArrayOf(shape0) + restOfShape, init)
 
     /**
      * Underlying storage. PureKt backend uses a simple array.
@@ -44,7 +47,7 @@ ${initStorage}
     // TODO: cache this
     override val size get() = storage.size
     override fun shape(): List<Int> = shape.toList()
-    override fun copy(): NDArray<${dtype}> = Default${dtypeName}NDArray(*shape, init = { this.getGeneric(*it) })
+    override fun copy(): NDArray<${dtype}> = Default${dtypeName}NDArray(shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
     private val wrongType = "Double methods not implemented for generic NDArray"

--- a/templates/DefaultXNDArrayFactory.kt
+++ b/templates/DefaultXNDArrayFactory.kt
@@ -15,9 +15,11 @@ class Default${dtype}NDArrayFactory: NumericalNDArrayFactory<${dtype}> {
 
     override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1${literalSuffix} }
 
-    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0${literalSuffix} }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().to${dtype}()
+    }
 
     override fun randn(vararg lengths: Int) = alloc(lengths).fill {
-        koma.internal.getRng().nextDouble().to${dtype}()
+        koma.internal.getRng().nextGaussian().to${dtype}()
     }
 }

--- a/templates/DefaultXNDArrayFactory.kt
+++ b/templates/DefaultXNDArrayFactory.kt
@@ -9,35 +9,15 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class Default${dtype}NDArrayFactory: NumericalNDArrayFactory<${dtype}> {
-    override fun create(vararg lengths: Int,
-                        filler: (IntArray) -> ${dtype}): NDArray<${dtype}> {
-        return Default${dtype}NDArray(*lengths).also {
-            it.fill{filler(it)}
-        }
-    }
+    override fun alloc(lengths: IntArray) = Default${dtype}NDArray(lengths)
 
-    override fun zeros(vararg lengths: Int): NDArray<${dtype}> {
-        return Default${dtype}NDArray(*lengths).fill {
-            0.to${dtype}()
-        }
-    }
+    override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0${literalSuffix} }
 
-    override fun ones(vararg lengths: Int): NDArray<${dtype}> {
-        return Default${dtype}NDArray(*lengths).fill {
-            1.to${dtype}()
-        }
-    }
+    override fun ones(vararg lengths: Int) = alloc(lengths).fill { 1${literalSuffix} }
 
-    override fun rand(vararg lengths: Int): NDArray<${dtype}> {
-        return Default${dtype}NDArray(*lengths).fill {
-            0.to${dtype}()
-        }
-    }
+    override fun rand(vararg lengths: Int) = alloc(lengths).fill { 0${literalSuffix} }
 
-    override fun randn(vararg lengths: Int): NDArray<${dtype}> {
-        return Default${dtype}NDArray(*lengths).fill {
-            koma.internal.getRng().nextDouble().to${dtype}()
-        }
+    override fun randn(vararg lengths: Int) = alloc(lengths).fill {
+        koma.internal.getRng().nextDouble().to${dtype}()
     }
-
 }

--- a/templates/DefaultXNDArrayFactory.kt
+++ b/templates/DefaultXNDArrayFactory.kt
@@ -9,7 +9,7 @@ import koma.extensions.fill
 import koma.ndarray.*
 
 class Default${dtype}NDArrayFactory: NumericalNDArrayFactory<${dtype}> {
-    override fun alloc(lengths: IntArray) = Default${dtype}NDArray(lengths)
+    override fun alloc(lengths: IntArray) = Default${dtype}NDArray(shape = *lengths)
 
     override fun zeros(vararg lengths: Int) = alloc(lengths).fill { 0${literalSuffix} }
 

--- a/templates/NDArray.kt
+++ b/templates/NDArray.kt
@@ -1,0 +1,88 @@
+package koma.ndarray
+
+import koma.extensions.create
+import koma.extensions.fill
+import koma.internal.*
+import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
+import koma.internal.default.utils.safeIdxToLinear
+import koma.matrix.*
+import kotlin.reflect.KClass
+import koma.util.IndexIterator
+
+// TODO: broadcasting, iteration by selected dims, views, reshape
+/**
+ * A general N-dimensional container for arbitrary types. For this container to be
+ * useful, you'll probably want to import koma.extensions.*, which includes e.g.
+ * element getter/setters which are non boxed for primitives.
+ *
+ * If you are looking for a 2D container supporting linear algebra, please look at
+ * [Matrix].
+ */
+interface NDArray<T> {
+    companion object {
+
+        // TODO: Ideally these properties are expect/actual with implementations. However, there's currently
+        // a generation issue with kotlin/native that breaks this approach, so as a workaround we'll define
+        // getXFactory methods in koma.internal as expect actual and proxy them here. These properties have
+        // to be lazily evaluated to avoid a race on startup in js, so we use private nullable fields and
+        // initialize on first use
+
+        $factories
+
+        fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
+            DefaultGenericNDArrayFactory<T>().create(*dims, filler = filler)
+
+        inline operator fun <reified T> invoke(vararg dims: Int,
+                                               crossinline filler: (IntArray) -> T) =
+            when(T::class) {
+                $typeCheckClauses
+                else          -> createGeneric(*dims) { filler(it) }
+            }
+    }
+
+    @Deprecated("Use NDArray.getGeneric", ReplaceWith("getGeneric"))
+    fun getLinear(index: Int): T = getGeneric(index)
+    @Deprecated("Use NDArray.getGeneric", ReplaceWith("setGeneric"))
+    fun setLinear(index: Int, value: T) = setGeneric(index, v = value)
+
+    val size: Int get() = shape().reduce { a, b -> a * b }
+    fun shape(): List<Int>
+    fun copy(): NDArray<T>
+
+    fun getBaseArray(): Any
+
+    fun toIterable(): Iterable<T> {
+        return object: Iterable<T> {
+            override fun iterator(): Iterator<T> = object: Iterator<T> {
+                private var cursor = 0
+                private val size = this@NDArray.size
+                override fun next(): T {
+                    cursor += 1
+                    // TODO: Either make 1D access work like Matrix or fix this
+                    // to not use the largest dimension.
+                    return this@NDArray.getLinear(cursor - 1)
+                }
+                override fun hasNext() = cursor < size
+            }
+        }
+    }
+
+    // Iterator over the indices of this NDArray, simultaneously in array and linear form.
+    // Not intended to be used directly, but instead used by ext funcs in `koma.extensions`
+    fun iterateIndices() = IndexIterator { shape().toIntArray() }
+
+
+    // Primitive optimized getter/setters to avoid boxing. Not intended
+    // to be used directly, but instead are used by ext funcs in `koma.extensions`.
+
+    @KomaJsName("getGenericND")
+    fun getGeneric(vararg indices: Int) = getGeneric(safeIdxToLinear(indices))
+    @KomaJsName("getGeneric1D")
+    fun getGeneric(i: Int): T
+    @KomaJsName("setGenericND")
+    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeIdxToLinear(indices), v)
+    @KomaJsName("setGeneric1D")
+    fun setGeneric(i: Int, v: T)
+
+    $primitiveGetSet
+}

--- a/templates/NDArray.kt
+++ b/templates/NDArray.kt
@@ -29,6 +29,9 @@ interface NDArray<T> {
 
         $factories
 
+        fun <T> allocGeneric(dims: IntArray) =
+            DefaultGenericNDArrayFactory<T>().alloc(dims)
+
         fun <T> createGeneric(vararg dims: Int, filler: (IntArray) -> T) =
             DefaultGenericNDArrayFactory<T>().create(*dims, filler = filler)
 

--- a/templates/NDArray.kt
+++ b/templates/NDArray.kt
@@ -4,7 +4,7 @@ import koma.extensions.create
 import koma.extensions.fill
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
-import koma.internal.default.utils.safeIdxToLinear
+import koma.internal.default.utils.safeNIdxToLinear
 import koma.matrix.*
 import kotlin.reflect.KClass
 import koma.util.IndexIterator
@@ -76,11 +76,11 @@ interface NDArray<T> {
     // to be used directly, but instead are used by ext funcs in `koma.extensions`.
 
     @KomaJsName("getGenericND")
-    fun getGeneric(vararg indices: Int) = getGeneric(safeIdxToLinear(indices))
+    fun getGeneric(vararg indices: Int) = getGeneric(safeNIdxToLinear(indices))
     @KomaJsName("getGeneric1D")
     fun getGeneric(i: Int): T
     @KomaJsName("setGenericND")
-    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeIdxToLinear(indices), v)
+    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeNIdxToLinear(indices), v)
     @KomaJsName("setGeneric1D")
     fun setGeneric(i: Int, v: T)
 

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -25,6 +25,17 @@ ${inline}fun ${genDec} NDArray<${dtype}>.fill(f: (idx: IntArray) -> ${dtype}) = 
         this.set${dtypeName}(linear, f(nd))
 }
 
+@koma.internal.JvmName("fill${dtypeName}Both")
+${inline}fun ${genDec} NDArray<${dtype}>.fillBoth(f: (nd: IntArray, linear: Int) -> ${dtype}) = apply {
+    for ((nd, linear) in this.iterateIndices())
+        this.set${dtypeName}(linear, f(nd, linear))
+}
+
+@koma.internal.JvmName("fill${dtypeName}Linear")
+${inline}fun ${genDec} NDArray<${dtype}>.fillLinear(f: (idx: Int) -> ${dtype}) = apply {
+    for (idx in 0 until size)
+        this.set${dtypeName}(idx, f(idx))
+}
 
 @koma.internal.JvmName("create${dtypeName}")
 ${inline}fun ${genDec} ${factoryPrefix}NDArrayFactory<${dtype}>.create(vararg lengths: Int, filler: (idx: IntArray) -> ${dtype})
@@ -39,13 +50,8 @@ ${inline}fun ${genDec} ${factoryPrefix}NDArrayFactory<${dtype}>.create(vararg le
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("map${dtypeName}")
-${inline}fun ${genDec} NDArray<${dtype}>.map(f: (${dtype}) -> ${dtype}): NDArray<${dtype}> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(ele))
-    return out
-}
+${inline}fun ${genDec} NDArray<${dtype}>.map(f: (${dtype}) -> ${dtype})
+    = ${factoryGetter}(shape().toIntArray()).fillLinear { f(this.get${dtypeName}(it)) }
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage
@@ -57,13 +63,8 @@ ${inline}fun ${genDec} NDArray<${dtype}>.map(f: (${dtype}) -> ${dtype}): NDArray
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapIndexed${dtypeName}")
-${inline}fun ${genDec} NDArray<${dtype}>.mapIndexed(f: (idx: Int, ele: ${dtype}) -> ${dtype}): NDArray<${dtype}> {
-    // TODO: Something better than copy here
-    val out = this.copy()
-    for ((idx, ele) in this.toIterable().withIndex())
-        out.setLinear(idx, f(idx, ele))
-    return out
-}
+${inline}fun ${genDec} NDArray<${dtype}>.mapIndexed(f: (idx: Int, ele: ${dtype}) -> ${dtype})
+    = ${factoryGetter}(shape().toIntArray()).fillLinear { f(it, this.get${dtypeName}(it)) }
 /**
  * Takes each element in a NDArray and passes them through f.
  *
@@ -72,8 +73,9 @@ ${inline}fun ${genDec} NDArray<${dtype}>.mapIndexed(f: (idx: Int, ele: ${dtype})
  */
 @koma.internal.JvmName("forEach${dtypeName}")
 ${inline}fun ${genDec} NDArray<${dtype}>.forEach(f: (ele: ${dtype}) -> Unit) {
-    for (ele in this.toIterable())
-        f(ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(get${dtypeName}(idx))
 }
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is a linear
@@ -85,11 +87,10 @@ ${inline}fun ${genDec} NDArray<${dtype}>.forEach(f: (ele: ${dtype}) -> Unit) {
  */
 @koma.internal.JvmName("forEachIndexed${dtypeName}")
 ${inline}fun $genDec NDArray<${dtype}>.forEachIndexed(f: (idx: Int, ele: ${dtype}) -> Unit) {
-    for ((idx, ele) in this.toIterable().withIndex())
-        f(idx, ele)
+    // TODO: Change this back to iteration once there are non-boxing iterators
+    for (idx in 0 until size)
+        f(idx, get${dtypeName}(idx))
 }
-
-// TODO: for both of these, batch compute [linearToNIdx] instead of computing for every ele
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
@@ -102,7 +103,7 @@ ${inline}fun $genDec NDArray<${dtype}>.forEachIndexed(f: (idx: Int, ele: ${dtype
  */
 @koma.internal.JvmName("mapIndexedN${dtypeName}")
 ${inline}fun $genDec NDArray<${dtype}>.mapIndexedN(f: (idx: IntArray, ele: ${dtype}) -> ${dtype}): NDArray<${dtype}>
-        = this.mapIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+    = ${factoryGetter}(shape().toIntArray()).fillBoth { nd, linear -> f(nd, get${dtypeName}(linear)) }
 
 /**
  * Takes each element in a NDArray and passes them through f. Index given to f is the full
@@ -113,8 +114,10 @@ ${inline}fun $genDec NDArray<${dtype}>.mapIndexedN(f: (idx: IntArray, ele: ${dty
  *
  */
 @koma.internal.JvmName("forEachIndexedN${dtypeName}")
-${inline}fun $genDec NDArray<${dtype}>.forEachIndexedN(f: (idx: IntArray, ele: ${dtype}) -> Unit)
-        = this.forEachIndexed { idx, ele -> f(linearToNIdx(idx), ele) }
+${inline}fun $genDec NDArray<${dtype}>.forEachIndexedN(f: (idx: IntArray, ele: ${dtype}) -> Unit) {
+    for ((nd, linear) in iterateIndices())
+        f(nd, get${dtypeName}(linear))
+}
 
 
 @koma.internal.JvmName("getRanges${dtypeName}")

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -120,7 +120,7 @@ ${inline}fun $genDec NDArray<${dtype}>.forEachIndexedN(f: (idx: IntArray, ele: $
 @koma.internal.JvmName("getRanges${dtypeName}")
 operator fun $genDec NDArray<${dtype}>.get(vararg indices: IntRange): NDArray<${dtype}> {
     checkIndices(indices.map { it.last }.toIntArray())
-    return DefaultGenericNDArray<${dtype}>(indices
+    return DefaultGenericNDArray<${dtype}>(shape = *indices
             .map { it.last - it.first + 1 }
             .toIntArray()) { newIdxs ->
         val offsets = indices.map { it.first }


### PR DESCRIPTION
**What It Does**
This PR enables a syntax on NDArray similar to Kotlin's `List(5) { "init" }`, using inlines to avoid boxing primitive values.

With this patch, the following code

```kotlin
val before = 5431
val nd = NDArray(1,3) { 0.5 }
val after = 1234
```

disassebles to this on the JVM:

```java
    if (Intrinsics.areEqual(var2, Reflection.getOrCreateKotlinClass(Double.TYPE))) {
         $receiver$iv$iv = this_$iv.getDoubleFactory().alloc(dims$iv);
         $receiver$iv$iv = $receiver$iv$iv;
         var6 = $receiver$iv$iv.iterateIndices().iterator();

         while(var6.hasNext()) {
            index$iv$iv = (IndexIterator)var6.next();
            var10001 = index$iv$iv.getLinear();
            it$iv = index$iv$iv.getNd();
            var9 = var10001;
            double var13 = 0.5D;
            $receiver$iv$iv.setDouble(var9, var13);
         }

         var10000 = $receiver$iv$iv;
    } else if /* more branches */
```

**Positive Side Effects**
* "rand" no longer returns zeros
* NDArray now has `.size`, like other collections.
* bounds checks on linear access
* The `IndexIterator` class, which I added as an implementation detail, has potential applications elsewhere in your extension functions (`mapIndexedN` for example could use it to avoid having to call `linearToNIdx` N times)

**Awkward Side-Effects**
* The "more branches" there are the other special cases for the other types, which means that using this function clutters the resulting `.class` with a bunch of unreachable bytecode.
* The `index` and `value` parameters in a lot of get/set methods have been renamed to `i` and `v` respectively, to match what Matrix does. This is because the Matrix versions of a lot of these became redundant as part of this work, and, knowing that Matrix is far more widely used than NDArray, I figured making the signature match Matrix would cause less breakage.
* Matrix.kt and NDArray.kt now contain generated code

**Mixed Bag**
* Fill no longer generates n copies of the indices array, so e.g. `NDArray(1, 2, 3) { it }` will result in an array with 6 references to the same `IntArray` instance in it. It's easy enough to add a .copy() if this is undesirable.
* `vararg` functions apparently generate an `Array.copy` call on the vararg parameter. To avoid copying the dims array N times when the new inline factory function is called, I added primitive-optimized versions of get/set for linear indices and changed DefaultNDArray's primary constructor to just take an array. To avoid breaking old code, I also added a secondary `constructor(shape0: Int, vararg restOfShape: Int` to try to avoid breaking people who are using the deprecated `DefaultNDArray(1, 2, 3) { "init" }`. I could not find a way to avoid breaking `DefaultNDArray(shape = *shape)`; any code which does this would have to remove the `*`
* I marked `getLinear`/`setLinear` as deprecated, because `get${dtype}`/`set${dtype}` now exist.