### PR TITLE
Array reshape

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -660,7 +660,7 @@ def factoryPattern(dtype, klass) {
     if (dtype == "T") {
         if (klass == "NDArray")
             return { "NDArray.createGeneric($it)" }
-        return { "${klass}($it)" }
+        return { "getFactory().zeros($it).fill" }
     } else
         return { "${klass}.${dtype.toLowerCase()}Factory.zeros($it).fill" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -302,6 +302,7 @@ project(':koma-tests') {
     }
     dependencies {
         testCompile "junit:junit:4.12"
+        testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
         testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
         testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
         testCompile project(':koma-core-mtj')
@@ -369,6 +370,7 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
                    genDec: genDec(dtype),
                    reifiedDec: reifiedDec(dtype),
                    reifiedInline: dtype == "T" ? "inline " : "",
+                   reshapeReceiverType: dtype == "T" ? "Matrix" : "NDArray",
                    factoryPattern: factoryPattern(dtype, "Matrix"),
                    floatersOnly: floatersOnly(dtype),
                    inline: inline(dtype))

--- a/build.gradle
+++ b/build.gradle
@@ -367,6 +367,8 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
             expand(dtype: dtype,
                    dtypeName: dtypeName(dtype),
                    genDec: genDec(dtype),
+                   reifiedDec: reifiedDec(dtype),
+                   reifiedInline: dtype == "T" ? "inline " : "",
                    floatersOnly: floatersOnly(dtype),
                    inline: inline(dtype))
         }

--- a/build.gradle
+++ b/build.gradle
@@ -369,6 +369,7 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
                    genDec: genDec(dtype),
                    reifiedDec: reifiedDec(dtype),
                    reifiedInline: dtype == "T" ? "inline " : "",
+                   factoryPattern: factoryPattern(dtype, "Matrix"),
                    floatersOnly: floatersOnly(dtype),
                    inline: inline(dtype))
         }
@@ -422,7 +423,7 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
                     toMatrix: toMatrix(dtype, dtypesMatrix),
                     operators: operators(dtype),
                     factoryPrefix: dtype == "T" ? "Generic" : "Numerical",
-                    factoryGetter: factoryGetter(dtype),
+                    factoryPattern: factoryPattern(dtype, "NDArray"),
                     inline: inline(dtype),
                     extensionMap: extensionMap(dtype),
                     extensionCreate: extensionCreate(dtype),
@@ -653,8 +654,13 @@ def inline(dtype) {
     }
 }
 
-def factoryGetter(dtype) {
-    dtype == "T" ? "NDArray.createGeneric<T>" : "NDArray.${dtype.toLowerCase()}Factory.zeros"
+def factoryPattern(dtype, klass) {
+    if (dtype == "T") {
+        if (klass == "NDArray")
+            return { "NDArray.createGeneric($it)" }
+        return { "${klass}($it)" }
+    } else
+        return { "${klass}.${dtype.toLowerCase()}Factory.zeros($it).fill" }
 }
 
 String fixWhitespaceErrors(String input) {

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
@@ -9,6 +9,7 @@
 package koma.extensions
 
 import koma.matrix.Matrix
+import koma.ndarray.NDArray
 import koma.internal.KomaJsName
 import koma.internal.KomaJvmName
 
@@ -80,7 +81,7 @@ inline fun  Matrix<Double>.forEach(f: (Double) -> Unit) {
  */
 @KomaJsName("reshapeDouble")
 @KomaJvmName("reshapeDouble")
-fun  Matrix<Double>.reshape(rows: Int, cols: Int): Matrix<Double> {
+fun  NDArray<Double>.reshape(rows: Int, cols: Int): Matrix<Double> {
     if (rows * cols != size)
         throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
     var idx = 0

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
@@ -93,7 +93,7 @@ fun  NDArray<Double>.reshape(rows: Int, cols: Int): Matrix<Double> {
     if (rows * cols != size)
         throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
-    return Matrix(rows, cols) { _, _ -> getDouble(idx++) }
+    return Matrix.doubleFactory.zeros(rows, cols).fill { _, _ -> getDouble(idx++) }
 }
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
@@ -76,6 +76,18 @@ inline fun  Matrix<Double>.forEach(f: (Double) -> Unit) {
 }
 
 /**
+ * Returns a matrix with the same data, but shaped differently.
+ */
+@KomaJsName("reshapeDouble")
+@KomaJvmName("reshapeDouble")
+fun  Matrix<Double>.reshape(rows: Int, cols: Int): Matrix<Double> {
+    if (rows * cols != size)
+        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+    var idx = 0
+    return Matrix(rows, cols) { _, _ -> getDouble(idx++) }
+}
+
+/**
  * Passes each element in row major order into a function along with its index location.
  *
  * @param f A function that takes in a row,col position and an element value

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Double.kt
@@ -77,13 +77,21 @@ inline fun  Matrix<Double>.forEach(f: (Double) -> Unit) {
 }
 
 /**
- * Returns a matrix with the same data, but shaped differently.
+ * Returns a new Matrix with the given shape, populated with the data in this array.
+ *
+ * @param rows The number of rows in the desired matrix
+ * @param cols The number of columns in the desired matrix
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(rows, cols).toList()`
+ *
+ * @throws IllegalArgumentException when `rows * cols` does not equal [size]
  */
 @KomaJsName("reshapeDouble")
 @KomaJvmName("reshapeDouble")
 fun  NDArray<Double>.reshape(rows: Int, cols: Int): Matrix<Double> {
     if (rows * cols != size)
-        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+        throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
     return Matrix(rows, cols) { _, _ -> getDouble(idx++) }
 }

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
@@ -9,6 +9,7 @@
 package koma.extensions
 
 import koma.matrix.Matrix
+import koma.ndarray.NDArray
 import koma.internal.KomaJsName
 import koma.internal.KomaJvmName
 
@@ -80,7 +81,7 @@ inline fun  Matrix<Float>.forEach(f: (Float) -> Unit) {
  */
 @KomaJsName("reshapeFloat")
 @KomaJvmName("reshapeFloat")
-fun  Matrix<Float>.reshape(rows: Int, cols: Int): Matrix<Float> {
+fun  NDArray<Float>.reshape(rows: Int, cols: Int): Matrix<Float> {
     if (rows * cols != size)
         throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
     var idx = 0

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
@@ -77,13 +77,21 @@ inline fun  Matrix<Float>.forEach(f: (Float) -> Unit) {
 }
 
 /**
- * Returns a matrix with the same data, but shaped differently.
+ * Returns a new Matrix with the given shape, populated with the data in this array.
+ *
+ * @param rows The number of rows in the desired matrix
+ * @param cols The number of columns in the desired matrix
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(rows, cols).toList()`
+ *
+ * @throws IllegalArgumentException when `rows * cols` does not equal [size]
  */
 @KomaJsName("reshapeFloat")
 @KomaJvmName("reshapeFloat")
 fun  NDArray<Float>.reshape(rows: Int, cols: Int): Matrix<Float> {
     if (rows * cols != size)
-        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+        throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
     return Matrix(rows, cols) { _, _ -> getFloat(idx++) }
 }

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
@@ -76,6 +76,18 @@ inline fun  Matrix<Float>.forEach(f: (Float) -> Unit) {
 }
 
 /**
+ * Returns a matrix with the same data, but shaped differently.
+ */
+@KomaJsName("reshapeFloat")
+@KomaJvmName("reshapeFloat")
+fun  Matrix<Float>.reshape(rows: Int, cols: Int): Matrix<Float> {
+    if (rows * cols != size)
+        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+    var idx = 0
+    return Matrix(rows, cols) { _, _ -> getFloat(idx++) }
+}
+
+/**
  * Passes each element in row major order into a function along with its index location.
  *
  * @param f A function that takes in a row,col position and an element value

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Float.kt
@@ -93,7 +93,7 @@ fun  NDArray<Float>.reshape(rows: Int, cols: Int): Matrix<Float> {
     if (rows * cols != size)
         throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
-    return Matrix(rows, cols) { _, _ -> getFloat(idx++) }
+    return Matrix.floatFactory.zeros(rows, cols).fill { _, _ -> getFloat(idx++) }
 }
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
@@ -76,6 +76,18 @@ fun <T> Matrix<T>.forEach(f: (T) -> Unit) {
 }
 
 /**
+ * Returns a matrix with the same data, but shaped differently.
+ */
+@KomaJsName("reshapeGeneric")
+@KomaJvmName("reshapeGeneric")
+inline fun <reified T> Matrix<T>.reshape(rows: Int, cols: Int): Matrix<T> {
+    if (rows * cols != size)
+        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+    var idx = 0
+    return Matrix(rows, cols) { _, _ -> getGeneric(idx++) }
+}
+
+/**
  * Passes each element in row major order into a function along with its index location.
  *
  * @param f A function that takes in a row,col position and an element value

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
@@ -93,7 +93,7 @@ inline fun <reified T> Matrix<T>.reshape(rows: Int, cols: Int): Matrix<T> {
     if (rows * cols != size)
         throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
-    return Matrix(rows, cols) { _, _ -> getGeneric(idx++) }
+    return getFactory().zeros(rows, cols).fill { _, _ -> getGeneric(idx++) }
 }
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
@@ -9,6 +9,7 @@
 package koma.extensions
 
 import koma.matrix.Matrix
+import koma.ndarray.NDArray
 import koma.internal.KomaJsName
 import koma.internal.KomaJvmName
 
@@ -80,7 +81,7 @@ fun <T> Matrix<T>.forEach(f: (T) -> Unit) {
  */
 @KomaJsName("reshapeGeneric")
 @KomaJvmName("reshapeGeneric")
-inline fun <reified T> Matrix<T>.reshape(rows: Int, cols: Int): Matrix<T> {
+inline fun <reified T> NDArray<T>.reshape(rows: Int, cols: Int): Matrix<T> {
     if (rows * cols != size)
         throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
     var idx = 0

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
@@ -77,13 +77,21 @@ fun <T> Matrix<T>.forEach(f: (T) -> Unit) {
 }
 
 /**
- * Returns a matrix with the same data, but shaped differently.
+ * Returns a new Matrix with the given shape, populated with the data in this array.
+ *
+ * @param rows The number of rows in the desired matrix
+ * @param cols The number of columns in the desired matrix
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(rows, cols).toList()`
+ *
+ * @throws IllegalArgumentException when `rows * cols` does not equal [size]
  */
 @KomaJsName("reshapeGeneric")
 @KomaJvmName("reshapeGeneric")
 inline fun <reified T> NDArray<T>.reshape(rows: Int, cols: Int): Matrix<T> {
     if (rows * cols != size)
-        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+        throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
     return Matrix(rows, cols) { _, _ -> getGeneric(idx++) }
 }

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Generic.kt
@@ -89,7 +89,7 @@ fun <T> Matrix<T>.forEach(f: (T) -> Unit) {
  */
 @KomaJsName("reshapeGeneric")
 @KomaJvmName("reshapeGeneric")
-inline fun <reified T> NDArray<T>.reshape(rows: Int, cols: Int): Matrix<T> {
+inline fun <reified T> Matrix<T>.reshape(rows: Int, cols: Int): Matrix<T> {
     if (rows * cols != size)
         throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
@@ -9,6 +9,7 @@
 package koma.extensions
 
 import koma.matrix.Matrix
+import koma.ndarray.NDArray
 import koma.internal.KomaJsName
 import koma.internal.KomaJvmName
 
@@ -80,7 +81,7 @@ inline fun  Matrix<Int>.forEach(f: (Int) -> Unit) {
  */
 @KomaJsName("reshapeInt")
 @KomaJvmName("reshapeInt")
-fun  Matrix<Int>.reshape(rows: Int, cols: Int): Matrix<Int> {
+fun  NDArray<Int>.reshape(rows: Int, cols: Int): Matrix<Int> {
     if (rows * cols != size)
         throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
     var idx = 0

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
@@ -76,6 +76,18 @@ inline fun  Matrix<Int>.forEach(f: (Int) -> Unit) {
 }
 
 /**
+ * Returns a matrix with the same data, but shaped differently.
+ */
+@KomaJsName("reshapeInt")
+@KomaJvmName("reshapeInt")
+fun  Matrix<Int>.reshape(rows: Int, cols: Int): Matrix<Int> {
+    if (rows * cols != size)
+        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+    var idx = 0
+    return Matrix(rows, cols) { _, _ -> getInt(idx++) }
+}
+
+/**
  * Passes each element in row major order into a function along with its index location.
  *
  * @param f A function that takes in a row,col position and an element value

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
@@ -93,7 +93,7 @@ fun  NDArray<Int>.reshape(rows: Int, cols: Int): Matrix<Int> {
     if (rows * cols != size)
         throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
-    return Matrix(rows, cols) { _, _ -> getInt(idx++) }
+    return Matrix.intFactory.zeros(rows, cols).fill { _, _ -> getInt(idx++) }
 }
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_matrix_Int.kt
@@ -77,13 +77,21 @@ inline fun  Matrix<Int>.forEach(f: (Int) -> Unit) {
 }
 
 /**
- * Returns a matrix with the same data, but shaped differently.
+ * Returns a new Matrix with the given shape, populated with the data in this array.
+ *
+ * @param rows The number of rows in the desired matrix
+ * @param cols The number of columns in the desired matrix
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(rows, cols).toList()`
+ *
+ * @throws IllegalArgumentException when `rows * cols` does not equal [size]
  */
 @KomaJsName("reshapeInt")
 @KomaJvmName("reshapeInt")
 fun  NDArray<Int>.reshape(rows: Int, cols: Int): Matrix<Int> {
     if (rows * cols != size)
-        throw IllegalArgumentException("Matrix with $size items cannot be reshaped to $rows x $cols")
+        throw IllegalArgumentException("$size items cannot be reshaped to $rows x $cols")
     var idx = 0
     return Matrix(rows, cols) { _, _ -> getInt(idx++) }
 }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -42,6 +42,19 @@ inline fun  NDArray<Byte>.fillLinear(f: (idx: Int) -> Byte) = apply {
 inline fun  NumericalNDArrayFactory<Byte>.create(vararg lengths: Int, filler: (idx: IntArray) -> Byte)
     = NDArray.byteFactory.zeros(*lengths).fill(filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeByte")
+fun  NDArray<Byte>.reshape(vararg newShape: Int): NDArray<Byte> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getByte(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -58,7 +58,7 @@ fun  NDArray<Byte>.reshape(vararg dims: Int): NDArray<Byte> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getByte(idx++) }
+    return NDArray.byteFactory.zeros(*dims).fill { _ -> getByte(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -44,14 +44,21 @@ inline fun  NumericalNDArrayFactory<Byte>.create(vararg lengths: Int, filler: (i
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeByte")
-fun  NDArray<Byte>.reshape(vararg newShape: Int): NDArray<Byte> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+fun  NDArray<Byte>.reshape(vararg dims: Int): NDArray<Byte> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getByte(idx++) }
+    return NDArray(*dims) { _ -> getByte(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -54,14 +54,21 @@ inline fun  NumericalNDArrayFactory<Double>.create(vararg lengths: Int, filler: 
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeDouble")
-fun  NDArray<Double>.reshape(vararg newShape: Int): NDArray<Double> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+fun  NDArray<Double>.reshape(vararg dims: Int): NDArray<Double> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getDouble(idx++) }
+    return NDArray(*dims) { _ -> getDouble(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -52,6 +52,19 @@ inline fun  NDArray<Double>.fillLinear(f: (idx: Int) -> Double) = apply {
 inline fun  NumericalNDArrayFactory<Double>.create(vararg lengths: Int, filler: (idx: IntArray) -> Double)
     = NDArray.doubleFactory.zeros(*lengths).fill(filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeDouble")
+fun  NDArray<Double>.reshape(vararg newShape: Int): NDArray<Double> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getDouble(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -68,7 +68,7 @@ fun  NDArray<Double>.reshape(vararg dims: Int): NDArray<Double> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getDouble(idx++) }
+    return NDArray.doubleFactory.zeros(*dims).fill { _ -> getDouble(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -68,7 +68,7 @@ fun  NDArray<Float>.reshape(vararg dims: Int): NDArray<Float> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getFloat(idx++) }
+    return NDArray.floatFactory.zeros(*dims).fill { _ -> getFloat(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -54,14 +54,21 @@ inline fun  NumericalNDArrayFactory<Float>.create(vararg lengths: Int, filler: (
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeFloat")
-fun  NDArray<Float>.reshape(vararg newShape: Int): NDArray<Float> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+fun  NDArray<Float>.reshape(vararg dims: Int): NDArray<Float> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getFloat(idx++) }
+    return NDArray(*dims) { _ -> getFloat(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -52,6 +52,19 @@ inline fun  NDArray<Float>.fillLinear(f: (idx: Int) -> Float) = apply {
 inline fun  NumericalNDArrayFactory<Float>.create(vararg lengths: Int, filler: (idx: IntArray) -> Float)
     = NDArray.floatFactory.zeros(*lengths).fill(filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeFloat")
+fun  NDArray<Float>.reshape(vararg newShape: Int): NDArray<Float> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getFloat(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -55,14 +55,21 @@ fun <T> GenericNDArrayFactory<T>.create(vararg lengths: Int, filler: (idx: IntAr
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeGeneric")
-inline fun <reified T> NDArray<T>.reshape(vararg newShape: Int): NDArray<T> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+inline fun <reified T> NDArray<T>.reshape(vararg dims: Int): NDArray<T> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getGeneric(idx++) }
+    return NDArray(*dims) { _ -> getGeneric(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -69,7 +69,7 @@ inline fun <reified T> NDArray<T>.reshape(vararg dims: Int): NDArray<T> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getGeneric(idx++) }
+    return NDArray.createGeneric(*dims) { _ -> getGeneric(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -53,6 +53,19 @@ fun <T> NDArray<T>.fillLinear(f: (idx: Int) -> T) = apply {
 fun <T> GenericNDArrayFactory<T>.create(vararg lengths: Int, filler: (idx: IntArray) -> T)
     = NDArray.createGeneric<T>(*lengths, filler=filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeGeneric")
+inline fun <reified T> NDArray<T>.reshape(vararg newShape: Int): NDArray<T> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getGeneric(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -54,14 +54,21 @@ inline fun  NumericalNDArrayFactory<Int>.create(vararg lengths: Int, filler: (id
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeInt")
-fun  NDArray<Int>.reshape(vararg newShape: Int): NDArray<Int> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+fun  NDArray<Int>.reshape(vararg dims: Int): NDArray<Int> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getInt(idx++) }
+    return NDArray(*dims) { _ -> getInt(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -52,6 +52,19 @@ inline fun  NDArray<Int>.fillLinear(f: (idx: Int) -> Int) = apply {
 inline fun  NumericalNDArrayFactory<Int>.create(vararg lengths: Int, filler: (idx: IntArray) -> Int)
     = NDArray.intFactory.zeros(*lengths).fill(filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeInt")
+fun  NDArray<Int>.reshape(vararg newShape: Int): NDArray<Int> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getInt(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -68,7 +68,7 @@ fun  NDArray<Int>.reshape(vararg dims: Int): NDArray<Int> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getInt(idx++) }
+    return NDArray.intFactory.zeros(*dims).fill { _ -> getInt(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -44,14 +44,21 @@ inline fun  NumericalNDArrayFactory<Long>.create(vararg lengths: Int, filler: (i
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeLong")
-fun  NDArray<Long>.reshape(vararg newShape: Int): NDArray<Long> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+fun  NDArray<Long>.reshape(vararg dims: Int): NDArray<Long> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getLong(idx++) }
+    return NDArray(*dims) { _ -> getLong(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -58,7 +58,7 @@ fun  NDArray<Long>.reshape(vararg dims: Int): NDArray<Long> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getLong(idx++) }
+    return NDArray.longFactory.zeros(*dims).fill { _ -> getLong(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -42,6 +42,19 @@ inline fun  NDArray<Long>.fillLinear(f: (idx: Int) -> Long) = apply {
 inline fun  NumericalNDArrayFactory<Long>.create(vararg lengths: Int, filler: (idx: IntArray) -> Long)
     = NDArray.longFactory.zeros(*lengths).fill(filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeLong")
+fun  NDArray<Long>.reshape(vararg newShape: Int): NDArray<Long> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getLong(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -44,14 +44,21 @@ inline fun  NumericalNDArrayFactory<Short>.create(vararg lengths: Int, filler: (
 
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshapeShort")
-fun  NDArray<Short>.reshape(vararg newShape: Int): NDArray<Short> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+fun  NDArray<Short>.reshape(vararg dims: Int): NDArray<Short> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> getShort(idx++) }
+    return NDArray(*dims) { _ -> getShort(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -42,6 +42,19 @@ inline fun  NDArray<Short>.fillLinear(f: (idx: Int) -> Short) = apply {
 inline fun  NumericalNDArrayFactory<Short>.create(vararg lengths: Int, filler: (idx: IntArray) -> Short)
     = NDArray.shortFactory.zeros(*lengths).fill(filler)
 
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshapeShort")
+fun  NDArray<Short>.reshape(vararg newShape: Int): NDArray<Short> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with $size items cannot be reshaped to ${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> getShort(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -58,7 +58,7 @@ fun  NDArray<Short>.reshape(vararg dims: Int): NDArray<Short> {
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("$size items cannot be reshaped to ${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> getShort(idx++) }
+    return NDArray.shortFactory.zeros(*dims).fill { _ -> getShort(idx++) }
 }
 
 

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -63,6 +63,7 @@ interface NDArray<T> {
         fun <T> createGenericNulls(vararg dims: Int) =
                 DefaultGenericNDArrayFactory<T?>().createGeneric(*dims, filler = {null})
 
+        @Suppress("UNCHECKED_CAST")
         inline operator fun <reified T> invoke(vararg dims: Int,
                                                crossinline filler: (IntArray) -> T) =
             when(T::class) {
@@ -73,7 +74,7 @@ interface NDArray<T> {
                 Short::class  -> shortFactory.zeros(*dims).fill { filler(it) as Short }
                 Byte::class   -> byteFactory.zeros(*dims).fill { filler(it) as Byte }
                 else          -> createGeneric(*dims) { filler(it) }
-            }
+            } as NDArray<T>
     }
 
     @Deprecated("Use NDArray.getGeneric", ReplaceWith("getGeneric"))

--- a/koma-tests/test/koma/ExtensionsTests.kt
+++ b/koma-tests/test/koma/ExtensionsTests.kt
@@ -3,6 +3,7 @@ package koma
 import koma.extensions.*
 import koma.util.test.*
 import org.junit.Test
+import kotlin.test.assertFails
 
 //@formatter:off
 
@@ -338,4 +339,29 @@ class ExtensionsTests {
             assert(out[4] == "5.0")
         }
     }
+
+    @Test
+    fun testReshape() {
+        allBackends {
+            val a = mat[1,   2,  3 end
+                        4,   5,  6 end
+                        7,   8,  9 end
+                        10, 11, 12]
+            assertMatrixEquals(mat[ 1,  2 end
+                                    3,  4 end
+                                    5,  6 end
+                                    7,  8 end
+                                    9, 10 end
+                                   11, 12], a.reshape(6, 2))
+
+            assertFails("cannot be reshaped") {
+                a.reshape(6, 3)
+            }
+
+            assertFails("cannot be reshaped") {
+                a.reshape(2, 2)
+            }
+        }
+    }
+
 }

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -4,6 +4,7 @@ import koma.extensions.*
 import koma.ndarray.*
 import koma.ndarray.default.*
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
@@ -191,5 +192,20 @@ class NDTests {
         assert(NDArray(1, 2, 3) { it.reduce { a, b -> a + b } } is DefaultIntNDArray)
         assert(NDArray(1, 2, 3) { it.reduce { a, b -> a + b } }[0, 1, 2] == 3)
         assert(NDArray(1, 2, 3) { "${it.toList()}" }[0, 1, 1] == listOf(0,1,1).toString())
+    }
+
+
+    @Test
+    fun testReshapeND() {
+        var c = 0
+        val a = NDArray(1, 2, 3, 4) { ++c }
+
+        c = 0
+        val e = NDArray(4, 6) { ++c }
+        assertEquals(e.shape(), a.reshape(4, 6).shape())
+        assertEquals(e.toList(), a.reshape(4, 6).toList())
+
+        assertFails("cannot be reshaped") { a.reshape(7) }
+        assertFails("cannot be reshaped") { a.reshape(9, 9, 9) }
     }
 }

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -220,4 +220,15 @@ class NDTests {
 
         assertMatrixEquals(e, a.reshape(6, 2))
     }
+
+    @Test
+    fun testReshapeNDDoesNotTryToMatrixNonNumerical() {
+        var c = 0
+        val a = NDArray(1, 4) { "${c++}" }
+        c = 0
+        val e = NDArray(2, 2) { "${c++}" }
+
+        assertEquals(e.shape(), e.reshape(2, 2).shape())
+        assertEquals(e.toList(), a.toList())
+    }
 }

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -1,8 +1,10 @@
 package koma
 
 import koma.extensions.*
+import koma.matrix.Matrix
 import koma.ndarray.*
 import koma.ndarray.default.*
+import koma.util.test.assertMatrixEquals
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -207,5 +209,15 @@ class NDTests {
 
         assertFails("cannot be reshaped") { a.reshape(7) }
         assertFails("cannot be reshaped") { a.reshape(9, 9, 9) }
+    }
+
+    @Test
+    fun testReshapeNDBecomesMatirx() {
+        var c = 0
+        val a = NDArray(2, 2, 3) { ++c }
+        c = 0
+        val e = Matrix(6, 2) { _, _ -> ++c }
+
+        assertMatrixEquals(e, a.reshape(6, 2))
     }
 }

--- a/templates/NDArray.kt
+++ b/templates/NDArray.kt
@@ -35,12 +35,13 @@ interface NDArray<T> {
         fun <T> createGenericNulls(vararg dims: Int) =
                 DefaultGenericNDArrayFactory<T?>().createGeneric(*dims, filler = {null})
 
+        @Suppress("UNCHECKED_CAST")
         inline operator fun <reified T> invoke(vararg dims: Int,
                                                crossinline filler: (IntArray) -> T) =
             when(T::class) {
                 $typeCheckClauses
                 else          -> createGeneric(*dims) { filler(it) }
-            }
+            } as NDArray<T>
     }
 
     @Deprecated("Use NDArray.getGeneric", ReplaceWith("getGeneric"))

--- a/templates/extensions_matrix.kt
+++ b/templates/extensions_matrix.kt
@@ -89,7 +89,7 @@ ${inline}fun ${genDec} Matrix<${dtype}>.forEach(f: (${dtype}) -> Unit) {
  */
 @KomaJsName("reshape${dtypeName}")
 @KomaJvmName("reshape${dtypeName}")
-${reifiedInline}fun ${reifiedDec} NDArray<${dtype}>.reshape(rows: Int, cols: Int): Matrix<${dtype}> {
+${reifiedInline}fun ${reifiedDec} ${reshapeReceiverType}<${dtype}>.reshape(rows: Int, cols: Int): Matrix<${dtype}> {
     if (rows * cols != size)
         throw IllegalArgumentException("\$size items cannot be reshaped to \$rows x \$cols")
     var idx = 0

--- a/templates/extensions_matrix.kt
+++ b/templates/extensions_matrix.kt
@@ -77,13 +77,21 @@ ${inline}fun ${genDec} Matrix<${dtype}>.forEach(f: (${dtype}) -> Unit) {
 }
 
 /**
- * Returns a matrix with the same data, but shaped differently.
+ * Returns a new Matrix with the given shape, populated with the data in this array.
+ *
+ * @param rows The number of rows in the desired matrix
+ * @param cols The number of columns in the desired matrix
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(rows, cols).toList()`
+ *
+ * @throws IllegalArgumentException when `rows * cols` does not equal [size]
  */
 @KomaJsName("reshape${dtypeName}")
 @KomaJvmName("reshape${dtypeName}")
 ${reifiedInline}fun ${reifiedDec} NDArray<${dtype}>.reshape(rows: Int, cols: Int): Matrix<${dtype}> {
     if (rows * cols != size)
-        throw IllegalArgumentException("Matrix with \$size items cannot be reshaped to \$rows x \$cols")
+        throw IllegalArgumentException("\$size items cannot be reshaped to \$rows x \$cols")
     var idx = 0
     return Matrix(rows, cols) { _, _ -> get${dtypeName}(idx++) }
 }

--- a/templates/extensions_matrix.kt
+++ b/templates/extensions_matrix.kt
@@ -9,6 +9,7 @@
 package koma.extensions
 
 import koma.matrix.Matrix
+import koma.ndarray.NDArray
 import koma.internal.KomaJsName
 import koma.internal.KomaJvmName
 
@@ -80,7 +81,7 @@ ${inline}fun ${genDec} Matrix<${dtype}>.forEach(f: (${dtype}) -> Unit) {
  */
 @KomaJsName("reshape${dtypeName}")
 @KomaJvmName("reshape${dtypeName}")
-${reifiedInline}fun ${reifiedDec} Matrix<${dtype}>.reshape(rows: Int, cols: Int): Matrix<${dtype}> {
+${reifiedInline}fun ${reifiedDec} NDArray<${dtype}>.reshape(rows: Int, cols: Int): Matrix<${dtype}> {
     if (rows * cols != size)
         throw IllegalArgumentException("Matrix with \$size items cannot be reshaped to \$rows x \$cols")
     var idx = 0

--- a/templates/extensions_matrix.kt
+++ b/templates/extensions_matrix.kt
@@ -76,6 +76,18 @@ ${inline}fun ${genDec} Matrix<${dtype}>.forEach(f: (${dtype}) -> Unit) {
 }
 
 /**
+ * Returns a matrix with the same data, but shaped differently.
+ */
+@KomaJsName("reshape${dtypeName}")
+@KomaJvmName("reshape${dtypeName}")
+${reifiedInline}fun ${reifiedDec} Matrix<${dtype}>.reshape(rows: Int, cols: Int): Matrix<${dtype}> {
+    if (rows * cols != size)
+        throw IllegalArgumentException("Matrix with \$size items cannot be reshaped to \$rows x \$cols")
+    var idx = 0
+    return Matrix(rows, cols) { _, _ -> get${dtypeName}(idx++) }
+}
+
+/**
  * Passes each element in row major order into a function along with its index location.
  *
  * @param f A function that takes in a row,col position and an element value

--- a/templates/extensions_matrix.kt
+++ b/templates/extensions_matrix.kt
@@ -93,7 +93,7 @@ ${reifiedInline}fun ${reifiedDec} NDArray<${dtype}>.reshape(rows: Int, cols: Int
     if (rows * cols != size)
         throw IllegalArgumentException("\$size items cannot be reshaped to \$rows x \$cols")
     var idx = 0
-    return Matrix(rows, cols) { _, _ -> get${dtypeName}(idx++) }
+    return ${factoryPattern("rows, cols")} { _, _ -> get${dtypeName}(idx++) }
 }
 
 /**

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -43,14 +43,21 @@ ${inline}fun ${genDec} ${factoryPrefix}NDArrayFactory<${dtype}>.create(vararg le
 $extensionCreate
 
 /**
- * Returns an array with the same data, but shaped differently.
+ * Returns a new NDArray with the given shape, populated with the data in this array.
+ *
+ * @param dims Desired dimensions of the output array.
+ *
+ * @returns A copy of the elements in this array, shaped to the given number of rows and columns,
+ *          such that `this.toList() == this.reshape(*dims).toList()`
+ *
+ * @throws IllegalArgumentException when the product of all of the given `dims` does not equal [size]
  */
 @koma.internal.JvmName("reshape${dtypeName}")
-${reifiedInline}fun $reifiedDec NDArray<${dtype}>.reshape(vararg newShape: Int): NDArray<${dtype}> {
-    if (newShape.reduce { a, b -> a * b } != size)
-        throw IllegalArgumentException("NDArray with \$size items cannot be reshaped to \${newShape.toList()}")
+${reifiedInline}fun $reifiedDec NDArray<${dtype}>.reshape(vararg dims: Int): NDArray<${dtype}> {
+    if (dims.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("\$size items cannot be reshaped to \${dims.toList()}")
     var idx = 0
-    return NDArray(*newShape) { _ -> get${dtypeName}(idx++) }
+    return NDArray(*dims) { _ -> get${dtypeName}(idx++) }
 }
 
 

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -57,7 +57,7 @@ ${reifiedInline}fun $reifiedDec NDArray<${dtype}>.reshape(vararg dims: Int): NDA
     if (dims.reduce { a, b -> a * b } != size)
         throw IllegalArgumentException("\$size items cannot be reshaped to \${dims.toList()}")
     var idx = 0
-    return NDArray(*dims) { _ -> get${dtypeName}(idx++) }
+    return ${factoryPattern("*dims")} { _ -> get${dtypeName}(idx++) }
 }
 
 

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -41,6 +41,19 @@ ${inline}fun ${genDec} NDArray<${dtype}>.fillLinear(f: (idx: Int) -> ${dtype}) =
 @koma.internal.JvmName("create${dtypeName}")
 ${inline}fun ${genDec} ${factoryPrefix}NDArrayFactory<${dtype}>.create(vararg lengths: Int, filler: (idx: IntArray) -> ${dtype})
 $extensionCreate
+
+/**
+ * Returns an array with the same data, but shaped differently.
+ */
+@koma.internal.JvmName("reshape${dtypeName}")
+${reifiedInline}fun $reifiedDec NDArray<${dtype}>.reshape(vararg newShape: Int): NDArray<${dtype}> {
+    if (newShape.reduce { a, b -> a * b } != size)
+        throw IllegalArgumentException("NDArray with \$size items cannot be reshaped to \${newShape.toList()}")
+    var idx = 0
+    return NDArray(*newShape) { _ -> get${dtypeName}(idx++) }
+}
+
+
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray.


### PR DESCRIPTION
This PR introduces an array-reshaping function, loosely inspired by the one from numpy. `reshape` comes in two flavors:
- `NDArray<Double>.reshape(Int, Int): Matrix<Double>` is defined for Int and Float as well, allowing 2d reshape requests to return a matrix when possible.
- `NDArray<T>.reshape(vararg Int): NDArray<T>` catches the remaining cases.

Reshape uses the same row-major ordering as getLinear, and uses the code-generation gradle scripts to avoid boxing and reflection.

This PR also fixes a type inference bug I introduced in a previous PR, which stood in the way.