### PR TITLE
Implement toMatrix(), toVector(), matrixOf(), vectorOf()

### DIFF
--- a/koma-core-api/common/src/koma/extensions/matrix_cross.kt
+++ b/koma-core-api/common/src/koma/extensions/matrix_cross.kt
@@ -56,3 +56,69 @@ operator fun Int.times(other: Matrix<Double>) = other.times(this.toDouble())
  * Multiply a scalar by a matrix
  */
 operator fun Matrix<Double>.times(other: Int) = this * other.toDouble()
+
+/**
+ * Convert an `Iterable<T>` to a `Matrix<Double>`
+ */
+fun <T, N: Number> Iterable<T>.toMatrix(vararg selectors: (T) -> N): Matrix<kotlin.Double> {
+
+    val items = toList()
+
+    return koma.fill(items.size, selectors.size) { row, col -> selectors[col](items[row]).toDouble() }
+}
+
+/**
+ * Convert a `Iterable<T>` to a single column `Matrix<Double>`
+ */
+fun <T, N: Number> Iterable<T>.toVector(selector: (T) -> N): Matrix<kotlin.Double> {
+
+    val items = toList()
+
+    return koma.fill(items.size, 1) { row, _ -> selector(items[row]).toDouble() }
+}
+
+
+/**
+ * Convert a `Sequence<T>` to a `Matrix<Double>`
+ */
+fun <T, N: Number> Sequence<T>.toMatrix(vararg selectors: (T) -> N): Matrix<kotlin.Double> = toList().toMatrix(*selectors)
+
+@Suppress("ReplaceGetOrSet")
+        /**
+ * A helper function that allows for quick construction of matrix literals.
+ *
+ * For example, one can write
+ * ```
+ * var a = matrixOf[1,2,3 end
+ *                  4,5,6]
+ * ```
+ *
+ * to get a 2x3 [Matrix<Double>] with the given values. `end` is a helper object that indicates the end of a row
+ * to this object. Note that one currently cannot use this function to generate a column vector:
+ *
+ * ```// ERROR:```
+ *
+ * ```matrixOf[1 end 2 end 3]```
+ *
+ * Instead do this:
+ *
+ * ```// Define a column vector by transposing a row-vector```
+ *
+ * ```matrixOf[1, 2, 3].T```
+ */
+fun matrixOf(vararg ts: Any): Matrix<Double> = koma.mat.get(*ts)
+
+
+@Suppress("ReplaceGetOrSet")
+/**
+ * A helper function that allows for quick construction of a vector implemented as a Matrix.
+ *
+ * For example, one can write
+ * ```
+ * var a = vectorOf[1,2,3]
+ * ```
+ */
+fun vectorOf(vararg ts: Any): Matrix<Double>  {
+    if (ts.any { it is Pair<*,*> }) throw Exception("There can only be one row in a vector!")
+    return koma.mat.get(*ts).T
+}

--- a/koma-core-api/common/src/koma/extensions/matrix_cross.kt
+++ b/koma-core-api/common/src/koma/extensions/matrix_cross.kt
@@ -68,9 +68,20 @@ fun <T, N: Number> Iterable<T>.toMatrix(vararg selectors: (T) -> N): Matrix<kotl
 }
 
 /**
- * Convert a `Iterable<T>` to a single column `Matrix<Double>`
+ * Convert an `Iterable<T>` to a single column `Matrix<Double>`
  */
-fun <T, N: Number> Iterable<T>.toVector(selector: (T) -> N): Matrix<kotlin.Double> {
+fun <T, N: Number> Iterable<T>.toRowVector(selector: (T) -> N): Matrix<kotlin.Double> {
+
+    val items = toList()
+
+    return koma.fill(1, items.size) { _, col -> selector(items[col]).toDouble() }
+}
+
+
+/**
+ * Convert an `Iterable<T>` to a single column `Matrix<Double>`
+ */
+fun <T, N: Number> Iterable<T>.toColVector(selector: (T) -> N): Matrix<kotlin.Double> {
 
     val items = toList()
 
@@ -89,36 +100,41 @@ fun <T, N: Number> Sequence<T>.toMatrix(vararg selectors: (T) -> N): Matrix<kotl
  *
  * For example, one can write
  * ```
- * var a = matrixOf[1,2,3 end
- *                  4,5,6]
+ * val a = matrixOf(1,2,3 end
+ *                  4,5,6)
  * ```
  *
  * to get a 2x3 [Matrix<Double>] with the given values. `end` is a helper object that indicates the end of a row
- * to this object. Note that one currently cannot use this function to generate a column vector:
- *
- * ```// ERROR:```
- *
- * ```matrixOf[1 end 2 end 3]```
- *
- * Instead do this:
- *
- * ```// Define a column vector by transposing a row-vector```
- *
- * ```matrixOf[1, 2, 3].T```
+ * to this object.
  */
 fun matrixOf(vararg ts: Any): Matrix<Double> = koma.mat.get(*ts)
 
 
 @Suppress("ReplaceGetOrSet")
 /**
- * A helper function that allows for quick construction of a vector implemented as a Matrix.
+ * A helper function that allows for quick construction of a vertical vector implemented as a Matrix.
  *
  * For example, one can write
  * ```
- * var a = vectorOf[1,2,3]
+ * val a = colVectorOf(1,2,3)
  * ```
  */
-fun vectorOf(vararg ts: Any): Matrix<Double>  {
+fun colVectorOf(vararg ts: Any): Matrix<Double>  {
     if (ts.any { it is Pair<*,*> }) throw Exception("There can only be one row in a vector!")
     return koma.mat.get(*ts).T
+}
+
+
+@Suppress("ReplaceGetOrSet")
+/**
+ * A helper function that allows for quick construction of a horizontal vector implemented as a Matrix.
+ *
+ * For example, one can write
+ * ```
+ * val a = rowVectorOf(1,2,3)
+ * ```
+ */
+fun rowVectorOf(vararg ts: Any): Matrix<Double>  {
+    if (ts.any { it is Pair<*,*> }) throw Exception("There can only be one column in a vector!")
+    return koma.mat.get(*ts)
 }

--- a/koma-tests/test/koma/CreatorsTests.kt
+++ b/koma-tests/test/koma/CreatorsTests.kt
@@ -140,7 +140,62 @@ class CreatorsTests {
             assertFalse { (b-c).any { it == 0.0 } }
         }
     }
+    @Test
+    fun testToMatrix() {
+        allBackends {
+            val a = (0..9)
+                    .toMatrix(
+                            {it},
+                            {it * 100}
+                    )
 
+            (0..9).forEach {
+                        assertEquals(a[it,0], it.toDouble())
+                        assertEquals(a[it,1], it.toDouble() * 100.0)
+                    }
+        }
+    }
+
+    @Test
+    fun testToVector() {
+        allBackends {
+            val a = (0..9)
+                    .toVector { it }
+
+            (0..9).forEach {
+                assertEquals(a[it,0], it.toDouble())
+            }
+        }
+    }
+
+    @Test
+    fun testMatrixOf() {
+        val a = matrixOf(0, 1, 2 end 3, 4, 5)
+
+        (0..2).forEach { c ->
+            (0..1).forEach { r ->
+                assertEquals(a[r,c], c.toDouble() + (r.toDouble()*3.0))
+            }
+        }
+    }
+
+    @Test
+    fun testVectorOfPass() {
+        val v = vectorOf(1,2,3)
+        (0..2).forEach {
+            assertEquals(v[0,1], it.toDouble())
+        }
+    }
+
+    @Test
+    fun testVectorFail() {
+        try {
+            vectorOf(1, 2 end 3, 4)
+        } catch (e: Exception) {
+            return
+        }
+        throw Exception("testVectorFail() didn't fail")
+    }
     @Test
     fun testSeed() {
         allBackends {

--- a/koma-tests/test/koma/CreatorsTests.kt
+++ b/koma-tests/test/koma/CreatorsTests.kt
@@ -157,16 +157,27 @@ class CreatorsTests {
     }
 
     @Test
-    fun testToVector() {
+    fun testToColVector() {
         allBackends {
-            val a = (0..9)
-                    .toVector { it }
+            val a = (0..9).toColVector { it }
 
             (0..9).forEach {
                 assertEquals(a[it,0], it.toDouble())
             }
         }
     }
+
+    @Test
+    fun testToRowVector() {
+        allBackends {
+            val a = (0..9).toRowVector { it }
+
+            (0..9).forEach {
+                assertEquals(a[0,it], it.toDouble())
+            }
+        }
+    }
+
 
     @Test
     fun testMatrixOf() {
@@ -180,22 +191,37 @@ class CreatorsTests {
     }
 
     @Test
-    fun testVectorOfPass() {
-        val v = vectorOf(1,2,3)
+    fun testVectorColPass() {
+        val v = colVectorOf(0,1,2)
         (0..2).forEach {
-            assertEquals(v[0,1], it.toDouble())
+            assertEquals(v[it,0], it.toDouble())
         }
     }
 
     @Test
-    fun testVectorFail() {
-        try {
-            vectorOf(1, 2 end 3, 4)
-        } catch (e: Exception) {
-            return
+    fun testVectorColFail() {
+        assertFails {
+            colVectorOf(1, 2 end 3, 4)
         }
-        throw Exception("testVectorFail() didn't fail")
     }
+
+
+    @Test
+    fun testVectorRowPass() {
+        val v = rowVectorOf(0,1,2)
+        (0..2).forEach {
+            assertEquals(v[0,it], it.toDouble())
+        }
+    }
+
+    @Test
+    fun testVectorRowFail() {
+        assertFails {
+            rowVectorOf(1, 2 end 3, 4)
+
+        }
+    }
+
     @Test
     fun testSeed() {
         allBackends {


### PR DESCRIPTION
I implemented some syntactic sugar to turn an `Iterable<T>` or `Sequence<T>` into a `Matrix<N>`.  This can be used via `toMatrix()` and `toVector()`. 

```kotlin 
import javafx.scene.paint.Color
import koma.matrix.Matrix

fun main(args: Array<String>) {

    val colors = sequenceOf(
            Color.RED,
            Color.PINK,
            Color.YELLOW,
            Color.BLUE,
            Color.GREEN
    )

    val matrix = colors.toMatrix(
            { it.red },
            { it.green },
            { it.blue }
    )

    println(matrix)
}
```

I also implemented a `matrixOf()` and `vectorOf()` set of functions to follow Kotlin idioms. 


```kotlin 
val a = matrixOf(0, 1, 2 end 3, 4, 5)
```