### PR TITLE
NDArray.map() can have different input and output types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,7 +400,8 @@ void genNDArray(String dest, List<String> dtypesNDArray) {
         include 'NDArray.kt'
         expand(factories: fixWhitespaceErrors(factories(dtypesNDArray)),
                primitiveGetSet: fixWhitespaceErrors(primitiveGetSet(dtypesNDArray)),
-               typeCheckClauses: fixWhitespaceErrors(typeCheckClauses(dtypesNDArray)))
+               typeCheckClauses: fixWhitespaceErrors(typeCheckClauses(dtypesNDArray)),
+               typeCheckClausesLinear: fixWhitespaceErrors(typeCheckClausesLinear(dtypesNDArray)))
     }
 }
 
@@ -490,6 +491,8 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
                     dtypeName: dtypeName(dtype),
                     genDec: genDec(dtype),
                     reifiedDec: reifiedDec(dtype),
+                    mapDec: mapDec(dtype),
+                    mapCrossinline: mapCrossinline(dtype),
                     toMatrix: toMatrix(dtype, dtypesMatrix),
                     operators: operators(dtype),
                     factoryPrefix: dtype == "T" ? "Generic" : "Numerical",
@@ -552,6 +555,14 @@ def genDec(dtype) {
 
 def reifiedDec(dtype) {
     dtype == 'T' ? "<reified T>" : ""
+}
+
+def mapDec(dtype) {
+    dtype == 'T' ? "<T, R>" : "<reified R>"
+}
+
+def mapCrossinline(dtype) {
+    dtype == 'T' ? "" : "crossinline"
 }
 
 def initStorage(dtype) {
@@ -667,9 +678,9 @@ def extensionCreate(dtype) {
 }
 def extensionMap(dtype) {
     if (dtype != "T") {
-        return "    = NDArray.${dtype.toLowerCase()}Factory.zeros(*shape().toIntArray()).fillLinear { f(this.get${dtype}(it)) }\n"
+        return "    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.get${dtype}(it)) } )\n"
     } else {
-        return "    = NDArray.createGeneric<T>(*shape().toIntArray(), filler = { f(this.getGeneric(*it)) })\n"
+        return "    = NDArray.createGeneric(*shape().toIntArray(), filler = { f(this.getGeneric(*it)) })\n"
     }
 }
 def extensionMapIndexed(dtype) {
@@ -756,6 +767,13 @@ def primitiveGetSet(types) {
 def typeCheckClauses(types) {
     types.findAll { it != "T" }.collect {
         String.format("%-13s -> ${it.toLowerCase()}Factory.zeros(*dims).fill { filler(it) as $it }",
+                      "$it::class")
+    }.join("\n                ")
+}
+
+def typeCheckClausesLinear(types) {
+    types.findAll { it != "T" }.collect {
+        String.format("%-13s -> ${it.toLowerCase()}Factory.zeros(*dims).fillLinear { filler(it) as $it }",
                       "$it::class")
     }.join("\n                ")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -492,13 +492,11 @@ def genCode(project, namespace, dtypesMatrix, dtypesNDArray, dtypeSuffixMap) {
                     genDec: genDec(dtype),
                     reifiedDec: reifiedDec(dtype),
                     mapDec: mapDec(dtype),
-                    mapCrossinline: mapCrossinline(dtype),
                     toMatrix: toMatrix(dtype, dtypesMatrix),
                     operators: operators(dtype),
                     factoryPrefix: dtype == "T" ? "Generic" : "Numerical",
                     factoryPattern: factoryPattern(dtype, "NDArray"),
                     inline: inline(dtype),
-                    extensionMap: extensionMap(dtype),
                     extensionCreate: extensionCreate(dtype),
                     extensionMapIndexed: extensionMapIndexed(dtype),
                     extensionMapIndexedN: extensionMapIndexedN(dtype),
@@ -558,11 +556,7 @@ def reifiedDec(dtype) {
 }
 
 def mapDec(dtype) {
-    dtype == 'T' ? "<T, R>" : "<reified R>"
-}
-
-def mapCrossinline(dtype) {
-    dtype == 'T' ? "" : "crossinline"
+    dtype == 'T' ? "<T, reified R>" : "<reified R>"
 }
 
 def initStorage(dtype) {
@@ -674,13 +668,6 @@ def extensionCreate(dtype) {
         return "    = NDArray.${dtype.toLowerCase()}Factory.zeros(*lengths).fill(filler)\n"
     } else {
         return "    = NDArray.createGeneric<T>(*lengths, filler=filler)\n"
-    }
-}
-def extensionMap(dtype) {
-    if (dtype != "T") {
-        return "    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.get${dtype}(it)) } )\n"
-    } else {
-        return "    = NDArray.createGeneric(*shape().toIntArray(), filler = { f(this.getGeneric(*it)) })\n"
     }
 }
 def extensionMapIndexed(dtype) {

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -71,8 +71,8 @@ fun  NDArray<Byte>.reshape(vararg dims: Int): NDArray<Byte> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapByte")
-inline fun  NDArray<Byte>.map(f: (Byte) -> Byte)
-    = NDArray.byteFactory.zeros(*shape().toIntArray()).fillLinear { f(this.getByte(it)) }
+inline fun <reified R> NDArray<Byte>.map(crossinline f: (Byte) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getByte(it)) } )
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -74,7 +74,6 @@ fun  NDArray<Byte>.reshape(vararg dims: Int): NDArray<Byte> {
 inline fun <reified R> NDArray<Byte>.map(crossinline f: (Byte) -> R)
     = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getByte(it)) } )
 
-
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -81,8 +81,8 @@ fun  NDArray<Double>.reshape(vararg dims: Int): NDArray<Double> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapDouble")
-inline fun  NDArray<Double>.map(f: (Double) -> Double)
-    = NDArray.doubleFactory.zeros(*shape().toIntArray()).fillLinear { f(this.getDouble(it)) }
+inline fun <reified R> NDArray<Double>.map(crossinline f: (Double) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getDouble(it)) } )
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -84,7 +84,6 @@ fun  NDArray<Double>.reshape(vararg dims: Int): NDArray<Double> {
 inline fun <reified R> NDArray<Double>.map(crossinline f: (Double) -> R)
     = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getDouble(it)) } )
 
-
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -84,7 +84,6 @@ fun  NDArray<Float>.reshape(vararg dims: Int): NDArray<Float> {
 inline fun <reified R> NDArray<Float>.map(crossinline f: (Float) -> R)
     = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getFloat(it)) } )
 
-
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -81,8 +81,8 @@ fun  NDArray<Float>.reshape(vararg dims: Int): NDArray<Float> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapFloat")
-inline fun  NDArray<Float>.map(f: (Float) -> Float)
-    = NDArray.floatFactory.zeros(*shape().toIntArray()).fillLinear { f(this.getFloat(it)) }
+inline fun <reified R> NDArray<Float>.map(crossinline f: (Float) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getFloat(it)) } )
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -82,9 +82,8 @@ inline fun <reified T> NDArray<T>.reshape(vararg dims: Int): NDArray<T> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapGeneric")
-fun <T, R> NDArray<T>.map( f: (T) -> R)
-    = NDArray.createGeneric(*shape().toIntArray(), filler = { f(this.getGeneric(*it)) })
-
+inline fun <T, reified R> NDArray<T>.map(crossinline f: (T) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getGeneric(it)) } )
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -82,8 +82,8 @@ inline fun <reified T> NDArray<T>.reshape(vararg dims: Int): NDArray<T> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapGeneric")
-fun <T> NDArray<T>.map(f: (T) -> T)
-    = NDArray.createGeneric<T>(*shape().toIntArray(), filler = { f(this.getGeneric(*it)) })
+fun <T, R> NDArray<T>.map( f: (T) -> R)
+    = NDArray.createGeneric(*shape().toIntArray(), filler = { f(this.getGeneric(*it)) })
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -84,7 +84,6 @@ fun  NDArray<Int>.reshape(vararg dims: Int): NDArray<Int> {
 inline fun <reified R> NDArray<Int>.map(crossinline f: (Int) -> R)
     = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getInt(it)) } )
 
-
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -81,8 +81,8 @@ fun  NDArray<Int>.reshape(vararg dims: Int): NDArray<Int> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapInt")
-inline fun  NDArray<Int>.map(f: (Int) -> Int)
-    = NDArray.intFactory.zeros(*shape().toIntArray()).fillLinear { f(this.getInt(it)) }
+inline fun <reified R> NDArray<Int>.map(crossinline f: (Int) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getInt(it)) } )
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -74,7 +74,6 @@ fun  NDArray<Long>.reshape(vararg dims: Int): NDArray<Long> {
 inline fun <reified R> NDArray<Long>.map(crossinline f: (Long) -> R)
     = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getLong(it)) } )
 
-
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -71,8 +71,8 @@ fun  NDArray<Long>.reshape(vararg dims: Int): NDArray<Long> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapLong")
-inline fun  NDArray<Long>.map(f: (Long) -> Long)
-    = NDArray.longFactory.zeros(*shape().toIntArray()).fillLinear { f(this.getLong(it)) }
+inline fun <reified R> NDArray<Long>.map(crossinline f: (Long) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getLong(it)) } )
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -71,8 +71,8 @@ fun  NDArray<Short>.reshape(vararg dims: Int): NDArray<Short> {
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("mapShort")
-inline fun  NDArray<Short>.map(f: (Short) -> Short)
-    = NDArray.shortFactory.zeros(*shape().toIntArray()).fillLinear { f(this.getShort(it)) }
+inline fun <reified R> NDArray<Short>.map(crossinline f: (Short) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getShort(it)) } )
 
 
 /**

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -74,7 +74,6 @@ fun  NDArray<Short>.reshape(vararg dims: Int): NDArray<Short> {
 inline fun <reified R> NDArray<Short>.map(crossinline f: (Short) -> R)
     = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.getShort(it)) } )
 
-
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an
  * output NDArray. Index given to f is a linear index, depending on the underlying storage

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -2,6 +2,7 @@ package koma.ndarray
 
 import koma.extensions.create
 import koma.extensions.fill
+import koma.extensions.fillLinear
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
 import koma.internal.default.utils.safeNIdxToLinear
@@ -74,6 +75,19 @@ interface NDArray<T> {
                 Short::class  -> shortFactory.zeros(*dims).fill { filler(it) as Short }
                 Byte::class   -> byteFactory.zeros(*dims).fill { filler(it) as Byte }
                 else          -> createGeneric(*dims) { filler(it) }
+            } as NDArray<T>
+
+        @Suppress("UNCHECKED_CAST")
+        inline fun <reified T> createLinear(vararg dims: Int,
+                                            crossinline filler: (Int) -> T) =
+            when(T::class) {
+                Double::class -> doubleFactory.zeros(*dims).fillLinear { filler(it) as Double }
+                Float::class  -> floatFactory.zeros(*dims).fillLinear { filler(it) as Float }
+                Long::class   -> longFactory.zeros(*dims).fillLinear { filler(it) as Long }
+                Int::class    -> intFactory.zeros(*dims).fillLinear { filler(it) as Int }
+                Short::class  -> shortFactory.zeros(*dims).fillLinear { filler(it) as Short }
+                Byte::class   -> byteFactory.zeros(*dims).fillLinear { filler(it) as Byte }
+                else          -> createGenericNulls<T>(*dims).fillLinear { filler(it) }
             } as NDArray<T>
     }
 

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -231,4 +231,18 @@ class NDTests {
         assertEquals(e.shape(), e.reshape(2, 2).shape())
         assertEquals(e.toList(), a.toList())
     }
+    
+    @Test
+    fun testMapBetweenTypes() {
+        val ints = NDArray.createLinear(2, 2, filler = { intArrayOf(5, 10, 0, 3)[it]})
+        val doubles = NDArray.createLinear(2, 2, filler = { doubleArrayOf(5.0, 10.0, 0.0, 3.0)[it]})
+        val strings = NDArray.createLinear(2, 2, filler = { arrayOf("5", "10", "0", "3")[it]})
+        val doublesFromInts = ints.map { it.toDouble() }
+        val stringsFromInts = ints.map { it.toString() }
+        val intsFromStrings = strings.map { it.toInt() }
+
+        assertEquals(doubles.toList(), doublesFromInts.toList())
+        assertEquals(strings.toList(), stringsFromInts.toList())
+        assertEquals(ints.toList(), intsFromStrings.toList())
+    }
 }

--- a/templates/NDArray.kt
+++ b/templates/NDArray.kt
@@ -2,6 +2,7 @@ package koma.ndarray
 
 import koma.extensions.create
 import koma.extensions.fill
+import koma.extensions.fillLinear
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
 import koma.internal.default.utils.safeNIdxToLinear
@@ -41,6 +42,14 @@ interface NDArray<T> {
             when(T::class) {
                 $typeCheckClauses
                 else          -> createGeneric(*dims) { filler(it) }
+            } as NDArray<T>
+
+        @Suppress("UNCHECKED_CAST")
+        inline fun <reified T> createLinear(vararg dims: Int,
+                                            crossinline filler: (Int) -> T) =
+            when(T::class) {
+                $typeCheckClausesLinear
+                else          -> createGenericNulls<T>(*dims).fillLinear { filler(it) }
             } as NDArray<T>
     }
 

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -70,7 +70,7 @@ ${reifiedInline}fun $reifiedDec NDArray<${dtype}>.reshape(vararg dims: Int): NDA
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("map${dtypeName}")
-${inline}fun ${genDec} NDArray<${dtype}>.map(f: (${dtype}) -> ${dtype})
+${inline}fun ${mapDec} NDArray<${dtype}>.map(${mapCrossinline} f: (${dtype}) -> R)
 $extensionMap
 
 /**

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -70,8 +70,8 @@ ${reifiedInline}fun $reifiedDec NDArray<${dtype}>.reshape(vararg dims: Int): NDA
  * @return the new NDArray after each element is mapped through f
  */
 @koma.internal.JvmName("map${dtypeName}")
-${inline}fun ${mapDec} NDArray<${dtype}>.map(${mapCrossinline} f: (${dtype}) -> R)
-$extensionMap
+inline fun ${mapDec} NDArray<${dtype}>.map(crossinline f: (${dtype}) -> R)
+    = NDArray.createLinear(*shape().toIntArray(), filler={ f(this.get${dtypeName}(it)) } )
 
 /**
  * Takes each element in a NDArray, passes them through f, and puts the output of f into an


### PR DESCRIPTION
Implements #47.  The same change could also be made to `mapIndexed()` and `mapIndexedN()`, but for the moment I left those alone.