### PR TITLE
Optimized indexing of arrays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -740,11 +740,11 @@ def primitiveGetSet(types) {
     types.findAll { it != "T" }.collect {
         """
         @KomaJsName("get${it}ND")
-        fun get$it(vararg indices: Int) = get$it(safeNIdxToLinear(indices))
+        fun get$it(vararg indices: Int) = get$it(nIdxToLinear(indices))
         @KomaJsName("get${it}1D")
         fun get$it(i: Int): $it = (getGeneric(i) as Number).to$it()
         @KomaJsName("set${it}ND")
-        fun set$it(vararg indices: Int, v: $it) = set$it(safeNIdxToLinear(indices), v)
+        fun set$it(vararg indices: Int, v: $it) = set$it(nIdxToLinear(indices), v)
         @KomaJsName("set${it}1D")
         @Suppress("UNCHECKED_CAST")
         fun set$it(i: Int, v: $it) { setGeneric(i, v as T) }

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Byte.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxByte
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.NumericalNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Double.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxDouble
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.NumericalNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Float.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxFloat
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.NumericalNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Generic.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxGeneric
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.GenericNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Int.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxInt
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.NumericalNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Long.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxLong
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.NumericalNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
+++ b/koma-core-api/common/src/koma/extensions/extensions_ndarray_Short.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMaxShort
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.NumericalNDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator

--- a/koma-core-api/common/src/koma/internal/default/generated/matrix/DefaultDoubleMatrix.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/matrix/DefaultDoubleMatrix.kt
@@ -9,6 +9,7 @@ import koma.*
 import koma.extensions.*
 import koma.matrix.*
 import koma.internal.notImplemented
+import koma.internal.default.utils.*
 
 
 class DefaultDoubleMatrix (val rows: Int, 
@@ -74,13 +75,11 @@ class DefaultDoubleMatrix (val rows: Int,
         storage[i] = v
     }
     private fun setStorage(i: Int, j: Int, v: Double) {
-        checkBounds(i,j)
-        storage[this.cols*i+j] = v
+        storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)] = v
     }
 
     private fun getStorage(i: Int, j: Int): Double {
-        checkBounds(i,j)
-        return storage[this.cols*i+j]
+        return storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)]
     }
 
     private fun getStorage(i: Int): Double 
@@ -108,14 +107,12 @@ class DefaultDoubleMatrix (val rows: Int,
     override fun setGeneric(i: Int, j: Int, v: Double) { this.setStorage(i, j, v)}
     override fun getDoubleData(): DoubleArray = storage.map { it.toDouble() }.toDoubleArray()
     override fun getRow(row: Int): Matrix<Double> {
-        checkBounds(row, 0)
         val out = getFactory().zeros(1,cols)
         for (i in 0 until cols)
             out[i] = this[row, i]
         return out
     }
     override fun getCol(col: Int): Matrix<Double> {
-        checkBounds(0,col)
         val out = getFactory().zeros(rows,1)
         for (i in 0 until rows)
             out[i] = this[i, col]
@@ -123,13 +120,11 @@ class DefaultDoubleMatrix (val rows: Int,
     }
 
     override fun setCol(index: Int, col: Matrix<Double>) {
-        checkBounds(0,index)
         for (i in 0 until rows)
             this[i, index] = col[i]
     }
 
     override fun setRow(index: Int, row: Matrix<Double>) {
-        checkBounds(index, 0)
         for (i in 0 until cols)
             this[index, i] = row[i]
     }
@@ -222,9 +217,4 @@ class DefaultDoubleMatrix (val rows: Int,
             = storage
     override fun getFactory(): MatrixFactory<Matrix<Double>> 
             = DefaultDoubleMatrixFactory()
-    
-    private fun checkBounds(row: Int, col: Int) {
-        if (row >= rows || col >= cols)
-            throw IllegalArgumentException("row/col index out of bounds")
-    }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/matrix/DefaultFloatMatrix.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/matrix/DefaultFloatMatrix.kt
@@ -9,6 +9,7 @@ import koma.*
 import koma.extensions.*
 import koma.matrix.*
 import koma.internal.notImplemented
+import koma.internal.default.utils.*
 
 
 class DefaultFloatMatrix (val rows: Int, 
@@ -74,13 +75,11 @@ class DefaultFloatMatrix (val rows: Int,
         storage[i] = v
     }
     private fun setStorage(i: Int, j: Int, v: Float) {
-        checkBounds(i,j)
-        storage[this.cols*i+j] = v
+        storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)] = v
     }
 
     private fun getStorage(i: Int, j: Int): Float {
-        checkBounds(i,j)
-        return storage[this.cols*i+j]
+        return storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)]
     }
 
     private fun getStorage(i: Int): Float 
@@ -108,14 +107,12 @@ class DefaultFloatMatrix (val rows: Int,
     override fun setGeneric(i: Int, j: Int, v: Float) { this.setStorage(i, j, v)}
     override fun getDoubleData(): DoubleArray = storage.map { it.toDouble() }.toDoubleArray()
     override fun getRow(row: Int): Matrix<Float> {
-        checkBounds(row, 0)
         val out = getFactory().zeros(1,cols)
         for (i in 0 until cols)
             out[i] = this[row, i]
         return out
     }
     override fun getCol(col: Int): Matrix<Float> {
-        checkBounds(0,col)
         val out = getFactory().zeros(rows,1)
         for (i in 0 until rows)
             out[i] = this[i, col]
@@ -123,13 +120,11 @@ class DefaultFloatMatrix (val rows: Int,
     }
 
     override fun setCol(index: Int, col: Matrix<Float>) {
-        checkBounds(0,index)
         for (i in 0 until rows)
             this[i, index] = col[i]
     }
 
     override fun setRow(index: Int, row: Matrix<Float>) {
-        checkBounds(index, 0)
         for (i in 0 until cols)
             this[index, i] = row[i]
     }
@@ -222,9 +217,4 @@ class DefaultFloatMatrix (val rows: Int,
             = storage
     override fun getFactory(): MatrixFactory<Matrix<Float>> 
             = DefaultFloatMatrixFactory()
-    
-    private fun checkBounds(row: Int, col: Int) {
-        if (row >= rows || col >= cols)
-            throw IllegalArgumentException("row/col index out of bounds")
-    }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/matrix/DefaultIntMatrix.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/matrix/DefaultIntMatrix.kt
@@ -9,6 +9,7 @@ import koma.*
 import koma.extensions.*
 import koma.matrix.*
 import koma.internal.notImplemented
+import koma.internal.default.utils.*
 
 
 class DefaultIntMatrix (val rows: Int, 
@@ -68,13 +69,11 @@ class DefaultIntMatrix (val rows: Int,
         storage[i] = v
     }
     private fun setStorage(i: Int, j: Int, v: Int) {
-        checkBounds(i,j)
-        storage[this.cols*i+j] = v
+        storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)] = v
     }
 
     private fun getStorage(i: Int, j: Int): Int {
-        checkBounds(i,j)
-        return storage[this.cols*i+j]
+        return storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)]
     }
 
     private fun getStorage(i: Int): Int 
@@ -102,14 +101,12 @@ class DefaultIntMatrix (val rows: Int,
     override fun setGeneric(i: Int, j: Int, v: Int) { this.setStorage(i, j, v)}
     override fun getDoubleData(): DoubleArray = storage.map { it.toDouble() }.toDoubleArray()
     override fun getRow(row: Int): Matrix<Int> {
-        checkBounds(row, 0)
         val out = getFactory().zeros(1,cols)
         for (i in 0 until cols)
             out[i] = this[row, i]
         return out
     }
     override fun getCol(col: Int): Matrix<Int> {
-        checkBounds(0,col)
         val out = getFactory().zeros(rows,1)
         for (i in 0 until rows)
             out[i] = this[i, col]
@@ -117,13 +114,11 @@ class DefaultIntMatrix (val rows: Int,
     }
 
     override fun setCol(index: Int, col: Matrix<Int>) {
-        checkBounds(0,index)
         for (i in 0 until rows)
             this[i, index] = col[i]
     }
 
     override fun setRow(index: Int, row: Matrix<Int>) {
-        checkBounds(index, 0)
         for (i in 0 until cols)
             this[index, i] = row[i]
     }
@@ -216,9 +211,4 @@ class DefaultIntMatrix (val rows: Int,
             = storage
     override fun getFactory(): MatrixFactory<Matrix<Int>> 
             = DefaultIntMatrixFactory()
-    
-    private fun checkBounds(row: Int, col: Int) {
-        if (row >= rows || col >= cols)
-            throw IllegalArgumentException("row/col index out of bounds")
-    }
 }

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultByteNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: ByteArray
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         storage = ByteArray(shape.reduce{ a, b-> a * b}, {init.invoke(linearToNIdx(it))}) 
@@ -43,10 +45,30 @@ open class DefaultByteNDArray(@KomaJsName("shape_private") vararg protected val 
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<Byte> = DefaultByteNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = storage[checkLinearIndex(i)]

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultDoubleNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: DoubleArray
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         storage = DoubleArray(shape.reduce{ a, b-> a * b}, {init.invoke(linearToNIdx(it))}) 
@@ -43,10 +45,30 @@ open class DefaultDoubleNDArray(@KomaJsName("shape_private") vararg protected va
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<Double> = DefaultDoubleNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = storage[checkLinearIndex(i)]

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultFloatNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: FloatArray
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         storage = FloatArray(shape.reduce{ a, b-> a * b}, {init.invoke(linearToNIdx(it))}) 
@@ -43,10 +45,30 @@ open class DefaultFloatNDArray(@KomaJsName("shape_private") vararg protected val
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<Float> = DefaultFloatNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = storage[checkLinearIndex(i)]

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultGenericNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultGenericNDArray<T>(@KomaJsName("shape_private") vararg protecte
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: Array<T>
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         @Suppress("UNCHECKED_CAST")
@@ -43,10 +45,30 @@ open class DefaultGenericNDArray<T>(@KomaJsName("shape_private") vararg protecte
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<T> = DefaultGenericNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = getGeneric(i)

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultIntNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: IntArray
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         storage = IntArray(shape.reduce{ a, b-> a * b}, {init.invoke(linearToNIdx(it))}) 
@@ -43,10 +45,30 @@ open class DefaultIntNDArray(@KomaJsName("shape_private") vararg protected val s
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<Int> = DefaultIntNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = storage[checkLinearIndex(i)]

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultLongNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: LongArray
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         storage = LongArray(shape.reduce{ a, b-> a * b}, {init.invoke(linearToNIdx(it))}) 
@@ -43,10 +45,30 @@ open class DefaultLongNDArray(@KomaJsName("shape_private") vararg protected val 
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<Long> = DefaultLongNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = storage[checkLinearIndex(i)]

--- a/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
+++ b/koma-core-api/common/src/koma/internal/default/generated/ndarray/DefaultShortNDArray.kt
@@ -24,6 +24,8 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
      * Underlying storage. Default backends uses a simple array.
      */
     private val storage: ShortArray
+    private val shapeAsList: List<Int> = shape.toList()
+    private val widthOfDims: IntArray = widthOfDims(shapeAsList)
 
     init {
         storage = ShortArray(shape.reduce{ a, b-> a * b}, {init.invoke(linearToNIdx(it))}) 
@@ -43,10 +45,30 @@ open class DefaultShortNDArray(@KomaJsName("shape_private") vararg protected val
     }
     // TODO: cache this
     override val size get() = storage.size
-    override fun shape(): List<Int> = shape.toList()
+    override fun shape(): List<Int> = shapeAsList
     override fun copy(): NDArray<Short> = DefaultShortNDArray(*shape, init = { this.getGeneric(*it) })
     override fun getBaseArray(): Any = storage
 
+    override fun nIdxToLinear(indices: IntArray): Int {
+        if (indices.size != shape.size)
+            throw IllegalArgumentException("Cannot index an array with shape ${shapeAsList} with " +
+                    "anything other than ${shape.size} indices (${indices.size} given)")
+        var out = 0
+        indices.forEachIndexed { i, idxArr ->
+            out += wrapIndex(idxArr, shape[i]) * widthOfDims[i]
+        }
+        return out
+    }
+
+    override fun linearToNIdx(linear:Int): IntArray {
+        var remaining = linear
+        val out = kotlin.IntArray(shape.size, { it })
+        out.map { idx ->
+            out[idx] = remaining / widthOfDims[idx]
+            remaining -= out[idx] * widthOfDims[idx]
+        }
+        return out
+    }
     private val wrongType = "Double methods not implemented for generic NDArray"
     override fun getDouble(i: Int): Double {
         val ele = storage[checkLinearIndex(i)]

--- a/koma-core-api/common/src/koma/internal/default/utils/indexing.kt
+++ b/koma-core-api/common/src/koma/internal/default/utils/indexing.kt
@@ -2,42 +2,12 @@ package koma.internal.default.utils
 
 import koma.ndarray.NDArray
 
-/**
- * Given a ND index into this array, find the corresponding 1D index in the raw underlying
- * 1D storage array.
- */
-fun <T> NDArray<T>.nIdxToLinear(indices: IntArray): Int {
-    var out = 0
-    val widthOfDims = widthOfDims()
-
-    indices.forEachIndexed { i, idxArr ->
-        out += idxArr * widthOfDims[i]
-    }
-    return out
-}
-
-/**
- * Given the 1D index of an element in the underlying storage, find the corresponding
- * ND index. Inverse of [nIdxToLinear].
- */
-fun <T> NDArray<T>.linearToNIdx(linear:Int): IntArray {
-    // TODO: optimize this
-    val widthOfDims = widthOfDims()
-    var remaining = linear
-    val out = IntArray(shape().size, {it})
-    out.map { idx ->
-        out[idx] = remaining / widthOfDims[idx]
-        remaining -= out[idx] * widthOfDims[idx]
-    }
-    return out
-}
-fun <T> NDArray<T>.widthOfDims() = shape()
-        .toList()
+fun widthOfDims(shape: List<Int>) = shape
         .accumulateRight { left, right -> left * right }
         .apply {
             add(1)
             removeAt(0)
-        }
+        }.toIntArray()
 
 fun <T> NDArray<T>.checkIndices(indices: IntArray) = indices.also {
     val shape = shape()
@@ -50,8 +20,6 @@ fun <T> NDArray<T>.checkIndices(indices: IntArray) = indices.also {
                     "${indices.toList()} (out of bounds)")
     }
 }
-
-fun <T> NDArray<T>.safeNIdxToLinear(indices: IntArray) = nIdxToLinear(checkIndices(indices))
 
 fun <T> NDArray<T>.checkLinearIndex(index: Int) = index.also {
     if (index < 0)

--- a/koma-core-api/common/src/koma/ndarray/NDArray.kt
+++ b/koma-core-api/common/src/koma/ndarray/NDArray.kt
@@ -5,14 +5,11 @@
 
 package koma.ndarray
 
-import koma.extensions.create
 import koma.extensions.fill
 import koma.extensions.fillLinear
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
-import koma.internal.default.utils.safeNIdxToLinear
 import koma.matrix.*
-import kotlin.reflect.KClass
 import koma.util.IndexIterator
 
 // TODO: broadcasting, iteration by selected dims, views, reshape
@@ -160,80 +157,89 @@ interface NDArray<T> {
     // Not intended to be used directly, but instead used by ext funcs in `koma.extensions`
     fun iterateIndices() = IndexIterator { shape().toIntArray() }
 
+    /**
+     * Convert an N-dimensional index to a 1D index.  This is primarily for internal use.
+     */
+    fun nIdxToLinear(indices: IntArray): Int = throw NotImplementedError()
+
+    /**
+     * Convert a 1D index to an N-dimensional index.  This is primarily for internal use.
+     */
+    fun linearToNIdx(linear:Int): IntArray = throw NotImplementedError()
 
     // Primitive optimized getter/setters to avoid boxing. Not intended
     // to be used directly, but instead are used by ext funcs in `koma.extensions`.
 
     @KomaJsName("getGenericND")
-    fun getGeneric(vararg indices: Int) = getGeneric(safeNIdxToLinear(indices))
+    fun getGeneric(vararg indices: Int) = getGeneric(nIdxToLinear(indices))
     @KomaJsName("getGeneric1D")
     fun getGeneric(i: Int): T
     @KomaJsName("setGenericND")
-    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeNIdxToLinear(indices), v)
+    fun setGeneric(vararg indices: Int, v: T) = setGeneric(nIdxToLinear(indices), v)
     @KomaJsName("setGeneric1D")
     fun setGeneric(i: Int, v: T)
 
     @KomaJsName("getDoubleND")
-    fun getDouble(vararg indices: Int) = getDouble(safeNIdxToLinear(indices))
+    fun getDouble(vararg indices: Int) = getDouble(nIdxToLinear(indices))
     @KomaJsName("getDouble1D")
     fun getDouble(i: Int): Double = (getGeneric(i) as Number).toDouble()
     @KomaJsName("setDoubleND")
-    fun setDouble(vararg indices: Int, v: Double) = setDouble(safeNIdxToLinear(indices), v)
+    fun setDouble(vararg indices: Int, v: Double) = setDouble(nIdxToLinear(indices), v)
     @KomaJsName("setDouble1D")
     @Suppress("UNCHECKED_CAST")
     fun setDouble(i: Int, v: Double) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getFloatND")
-    fun getFloat(vararg indices: Int) = getFloat(safeNIdxToLinear(indices))
+    fun getFloat(vararg indices: Int) = getFloat(nIdxToLinear(indices))
     @KomaJsName("getFloat1D")
     fun getFloat(i: Int): Float = (getGeneric(i) as Number).toFloat()
     @KomaJsName("setFloatND")
-    fun setFloat(vararg indices: Int, v: Float) = setFloat(safeNIdxToLinear(indices), v)
+    fun setFloat(vararg indices: Int, v: Float) = setFloat(nIdxToLinear(indices), v)
     @KomaJsName("setFloat1D")
     @Suppress("UNCHECKED_CAST")
     fun setFloat(i: Int, v: Float) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getLongND")
-    fun getLong(vararg indices: Int) = getLong(safeNIdxToLinear(indices))
+    fun getLong(vararg indices: Int) = getLong(nIdxToLinear(indices))
     @KomaJsName("getLong1D")
     fun getLong(i: Int): Long = (getGeneric(i) as Number).toLong()
     @KomaJsName("setLongND")
-    fun setLong(vararg indices: Int, v: Long) = setLong(safeNIdxToLinear(indices), v)
+    fun setLong(vararg indices: Int, v: Long) = setLong(nIdxToLinear(indices), v)
     @KomaJsName("setLong1D")
     @Suppress("UNCHECKED_CAST")
     fun setLong(i: Int, v: Long) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getIntND")
-    fun getInt(vararg indices: Int) = getInt(safeNIdxToLinear(indices))
+    fun getInt(vararg indices: Int) = getInt(nIdxToLinear(indices))
     @KomaJsName("getInt1D")
     fun getInt(i: Int): Int = (getGeneric(i) as Number).toInt()
     @KomaJsName("setIntND")
-    fun setInt(vararg indices: Int, v: Int) = setInt(safeNIdxToLinear(indices), v)
+    fun setInt(vararg indices: Int, v: Int) = setInt(nIdxToLinear(indices), v)
     @KomaJsName("setInt1D")
     @Suppress("UNCHECKED_CAST")
     fun setInt(i: Int, v: Int) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getShortND")
-    fun getShort(vararg indices: Int) = getShort(safeNIdxToLinear(indices))
+    fun getShort(vararg indices: Int) = getShort(nIdxToLinear(indices))
     @KomaJsName("getShort1D")
     fun getShort(i: Int): Short = (getGeneric(i) as Number).toShort()
     @KomaJsName("setShortND")
-    fun setShort(vararg indices: Int, v: Short) = setShort(safeNIdxToLinear(indices), v)
+    fun setShort(vararg indices: Int, v: Short) = setShort(nIdxToLinear(indices), v)
     @KomaJsName("setShort1D")
     @Suppress("UNCHECKED_CAST")
     fun setShort(i: Int, v: Short) { setGeneric(i, v as T) }
 
 
     @KomaJsName("getByteND")
-    fun getByte(vararg indices: Int) = getByte(safeNIdxToLinear(indices))
+    fun getByte(vararg indices: Int) = getByte(nIdxToLinear(indices))
     @KomaJsName("getByte1D")
     fun getByte(i: Int): Byte = (getGeneric(i) as Number).toByte()
     @KomaJsName("setByteND")
-    fun setByte(vararg indices: Int, v: Byte) = setByte(safeNIdxToLinear(indices), v)
+    fun setByte(vararg indices: Int, v: Byte) = setByte(nIdxToLinear(indices), v)
     @KomaJsName("setByte1D")
     @Suppress("UNCHECKED_CAST")
     fun setByte(i: Int, v: Byte) { setGeneric(i, v as T) }

--- a/koma-tests/test/koma/NDTests.kt
+++ b/koma-tests/test/koma/NDTests.kt
@@ -37,6 +37,17 @@ class NDTests {
         assert(arr[1,3,0] == 1.0)
     }
     @Test
+    fun testNegativeIndices() {
+        val arr = ndArrayOf(1, 2, 3, 4, shape=intArrayOf(2, 2))
+        assert(arr[-2,-2] == 1)
+        assert(arr[0,-1] == 2)
+        assert(arr[-1,0] == 3)
+        arr[-2,-2] = 5
+        arr[1,-1] = 6
+        assert(arr[0,0] == 5)
+        assert(arr[1,1] == 6)
+    }
+    @Test
     fun testObject() {
         val arr = NDArray(2, 5, 2) { idx -> "str #${idx[0]},${idx[1]},${idx[2]}" }
         assert(arr[1,4,0] == "str #1,4,0")

--- a/templates/DefaultXMatrix.kt
+++ b/templates/DefaultXMatrix.kt
@@ -9,6 +9,7 @@ import koma.*
 import koma.extensions.*
 import koma.matrix.*
 import koma.internal.notImplemented
+import koma.internal.default.utils.*
 
 
 class Default${dtype}Matrix (val rows: Int, 
@@ -68,13 +69,11 @@ class Default${dtype}Matrix (val rows: Int,
         storage[i] = v
     }
     private fun setStorage(i: Int, j: Int, v: ${dtype}) {
-        checkBounds(i,j)
-        storage[this.cols*i+j] = v
+        storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)] = v
     }
 
     private fun getStorage(i: Int, j: Int): ${dtype} {
-        checkBounds(i,j)
-        return storage[this.cols*i+j]
+        return storage[this.cols*wrapIndex(i,rows) + wrapIndex(j,cols)]
     }
 
     private fun getStorage(i: Int): ${dtype} 
@@ -102,14 +101,12 @@ class Default${dtype}Matrix (val rows: Int,
     override fun setGeneric(i: Int, j: Int, v: ${dtype}) { this.setStorage(i, j, v)}
     override fun getDoubleData(): DoubleArray = storage.map { it.toDouble() }.toDoubleArray()
     override fun getRow(row: Int): Matrix<${dtype}> {
-        checkBounds(row, 0)
         val out = getFactory().zeros(1,cols)
         for (i in 0 until cols)
             out[i] = this[row, i]
         return out
     }
     override fun getCol(col: Int): Matrix<${dtype}> {
-        checkBounds(0,col)
         val out = getFactory().zeros(rows,1)
         for (i in 0 until rows)
             out[i] = this[i, col]
@@ -117,13 +114,11 @@ class Default${dtype}Matrix (val rows: Int,
     }
 
     override fun setCol(index: Int, col: Matrix<${dtype}>) {
-        checkBounds(0,index)
         for (i in 0 until rows)
             this[i, index] = col[i]
     }
 
     override fun setRow(index: Int, row: Matrix<${dtype}>) {
-        checkBounds(index, 0)
         for (i in 0 until cols)
             this[index, i] = row[i]
     }
@@ -216,9 +211,4 @@ class Default${dtype}Matrix (val rows: Int,
             = storage
     override fun getFactory(): MatrixFactory<Matrix<${dtype}>> 
             = Default${dtype}MatrixFactory()
-    
-    private fun checkBounds(row: Int, col: Int) {
-        if (row >= rows || col >= cols)
-            throw IllegalArgumentException("row/col index out of bounds")
-    }
 }

--- a/templates/NDArray.kt
+++ b/templates/NDArray.kt
@@ -5,14 +5,11 @@
 
 package koma.ndarray
 
-import koma.extensions.create
 import koma.extensions.fill
 import koma.extensions.fillLinear
 import koma.internal.*
 import koma.internal.default.generated.ndarray.DefaultGenericNDArrayFactory
-import koma.internal.default.utils.safeNIdxToLinear
 import koma.matrix.*
-import kotlin.reflect.KClass
 import koma.util.IndexIterator
 
 // TODO: broadcasting, iteration by selected dims, views, reshape
@@ -122,16 +119,25 @@ interface NDArray<T> {
     // Not intended to be used directly, but instead used by ext funcs in `koma.extensions`
     fun iterateIndices() = IndexIterator { shape().toIntArray() }
 
+    /**
+     * Convert an N-dimensional index to a 1D index.  This is primarily for internal use.
+     */
+    fun nIdxToLinear(indices: IntArray): Int = throw NotImplementedError()
+
+    /**
+     * Convert a 1D index to an N-dimensional index.  This is primarily for internal use.
+     */
+    fun linearToNIdx(linear:Int): IntArray = throw NotImplementedError()
 
     // Primitive optimized getter/setters to avoid boxing. Not intended
     // to be used directly, but instead are used by ext funcs in `koma.extensions`.
 
     @KomaJsName("getGenericND")
-    fun getGeneric(vararg indices: Int) = getGeneric(safeNIdxToLinear(indices))
+    fun getGeneric(vararg indices: Int) = getGeneric(nIdxToLinear(indices))
     @KomaJsName("getGeneric1D")
     fun getGeneric(i: Int): T
     @KomaJsName("setGenericND")
-    fun setGeneric(vararg indices: Int, v: T) = setGeneric(safeNIdxToLinear(indices), v)
+    fun setGeneric(vararg indices: Int, v: T) = setGeneric(nIdxToLinear(indices), v)
     @KomaJsName("setGeneric1D")
     fun setGeneric(i: Int, v: T)
 

--- a/templates/extensions_ndarray.kt
+++ b/templates/extensions_ndarray.kt
@@ -14,7 +14,6 @@ import koma.internal.default.utils.argMax${dtypeName}
 import koma.internal.default.utils.wrapIndex
 import koma.ndarray.NDArray
 import koma.ndarray.${factoryPrefix}NDArrayFactory
-import koma.internal.default.utils.nIdxToLinear
 import koma.pow
 import koma.matrix.Matrix
 import koma.util.IndexIterator


### PR DESCRIPTION
This is my attempt at fixing #93.  While I was at it, I also added support for negative indices in the places that didn't yet have it.

Here's the code I used to benchmark it.

```kotlin
val x = NDArray(1000, 1000, filler = { getRng().nextGaussian().toFloat() })
for (trial in 1..10) {
    var sum = 0f
    val time = measureNanoTime {
        for (i in 0 until 1000)
            for (j in 0 until 1000)
                sum += x[i, j]
    }
    println("$sum, $time")
}
```

With these changes, I'm getting a roughly 9x speedup.

You'll notice that I removed a lot of calls to functions that checked the ranges of indices.  That's because the same checks are now done in `wrapIndex()`, so there's no need to do them twice.  I did not remove the calls to `checkLinearIndex()`, but we could consider doing that too.  It isn't strictly necessary, since the storage array is already bounds checked.  The only benefit is that it produces a slightly nicer error message.  It's up to you whether that justifies the (probably small) cost of doing the bounds check twice.
