### PR TITLE
Fix transitive dependency on xchart

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -226,7 +226,7 @@ project(":koma-plotting") {
                     dependencies {
                         implementation(project(":koma-core-api"))
                         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-                        implementation("org.knowm.xchart:xchart:3.5.1")
+                        api("org.knowm.xchart:xchart:3.5.1")
                     }
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.code.style=official
 ### Publishing
 
 # Set up your maven coordinates here, artifactId is defined per project.
-version = 0.12.1
+version = 0.12.2
 group = com.kyonifer
 
 # Put link to your OSS repository. Bintray requires this to be filled for free OpenSource tiers.


### PR DESCRIPTION
[`koma.figures`](https://github.com/kyonifer/koma/blob/master/koma-plotting/src/koma/plot.kt#L35)' declared type is `Array<Triple<XYChart, JFrame, Int>>>`, but xchart in the dependency list is included as `implementation`, which causes the following compile error:

```
e: /path/to/your.kt: (285, 36): Cannot access class 'org.knowm.xchart.XYChart'. Check your module classpath for missing or conflicting dependencies
```

It's possible to work around this locally by adding `implementation "org.knowm.xchart:xchart:3.5.1"` to my project's build.gradle, but I believe the change proposed in this PR will cause gradle to automatically bring in that transitive dependency and eliminate the error.
